### PR TITLE
Fixed an enum comparison error

### DIFF
--- a/generated/src/FireflyIII/Api/AccountsApi.cs
+++ b/generated/src/FireflyIII/Api/AccountsApi.cs
@@ -36,7 +36,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="id">The ID of the account.</param>
         /// <returns></returns>
-        void DeleteAccount (int id);
+        void DeleteAccount(int id);
 
         /// <summary>
         /// Permanently delete account.
@@ -47,7 +47,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="id">The ID of the account.</param>
         /// <returns>ApiResponse of Object(void)</returns>
-        ApiResponse<Object> DeleteAccountWithHttpInfo (int id);
+        ApiResponse<Object> DeleteAccountWithHttpInfo(int id);
         /// <summary>
         /// Get single account.
         /// </summary>
@@ -58,7 +58,7 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <returns>AccountSingle</returns>
-        AccountSingle GetAccount (int id, DateTime? date = default(DateTime?));
+        AccountSingle GetAccount(int id, DateTime? date = default(DateTime?));
 
         /// <summary>
         /// Get single account.
@@ -70,7 +70,7 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <returns>ApiResponse of AccountSingle</returns>
-        ApiResponse<AccountSingle> GetAccountWithHttpInfo (int id, DateTime? date = default(DateTime?));
+        ApiResponse<AccountSingle> GetAccountWithHttpInfo(int id, DateTime? date = default(DateTime?));
         /// <summary>
         /// List all accounts.
         /// </summary>
@@ -82,7 +82,7 @@ namespace FireflyIII.Api
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <param name="type">Optional filter on the account type(s) returned (optional)</param>
         /// <returns>AccountArray</returns>
-        AccountArray ListAccount (int? page = default(int?), DateTime? date = default(DateTime?), AccountTypeFilter type = default(AccountTypeFilter));
+        AccountArray ListAccount(int? page = default(int?), DateTime? date = default(DateTime?), AccountTypeFilter type = default(AccountTypeFilter));
 
         /// <summary>
         /// List all accounts.
@@ -95,7 +95,7 @@ namespace FireflyIII.Api
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <param name="type">Optional filter on the account type(s) returned (optional)</param>
         /// <returns>ApiResponse of AccountArray</returns>
-        ApiResponse<AccountArray> ListAccountWithHttpInfo (int? page = default(int?), DateTime? date = default(DateTime?), AccountTypeFilter type = default(AccountTypeFilter));
+        ApiResponse<AccountArray> ListAccountWithHttpInfo(int? page = default(int?), DateTime? date = default(DateTime?), AccountTypeFilter type = default(AccountTypeFilter));
         /// <summary>
         /// List all piggy banks related to the account.
         /// </summary>
@@ -106,7 +106,7 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="page">Page number. The default pagination is per 50 items. (optional)</param>
         /// <returns>PiggyBankArray</returns>
-        PiggyBankArray ListPiggyBankByAccount (int id, int? page = default(int?));
+        PiggyBankArray ListPiggyBankByAccount(int id, int? page = default(int?));
 
         /// <summary>
         /// List all piggy banks related to the account.
@@ -118,7 +118,7 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="page">Page number. The default pagination is per 50 items. (optional)</param>
         /// <returns>ApiResponse of PiggyBankArray</returns>
-        ApiResponse<PiggyBankArray> ListPiggyBankByAccountWithHttpInfo (int id, int? page = default(int?));
+        ApiResponse<PiggyBankArray> ListPiggyBankByAccountWithHttpInfo(int id, int? page = default(int?));
         /// <summary>
         /// List all transactions related to the account.
         /// </summary>
@@ -133,7 +133,7 @@ namespace FireflyIII.Api
         /// <param name="end">A date formatted YYYY-MM-DD.  (optional)</param>
         /// <param name="type">Optional filter on the transaction type(s) returned. (optional)</param>
         /// <returns>TransactionArray</returns>
-        TransactionArray ListTransactionByAccount (int id, int? page = default(int?), int? limit = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter));
+        TransactionArray ListTransactionByAccount(int id, int? page = default(int?), int? limit = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter));
 
         /// <summary>
         /// List all transactions related to the account.
@@ -149,7 +149,7 @@ namespace FireflyIII.Api
         /// <param name="end">A date formatted YYYY-MM-DD.  (optional)</param>
         /// <param name="type">Optional filter on the transaction type(s) returned. (optional)</param>
         /// <returns>ApiResponse of TransactionArray</returns>
-        ApiResponse<TransactionArray> ListTransactionByAccountWithHttpInfo (int id, int? page = default(int?), int? limit = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter));
+        ApiResponse<TransactionArray> ListTransactionByAccountWithHttpInfo(int id, int? page = default(int?), int? limit = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter));
         /// <summary>
         /// Create new account.
         /// </summary>
@@ -159,7 +159,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="account">JSON array with the necessary account information or key&#x3D;value pairs. See the model for the exact specifications.</param>
         /// <returns>AccountSingle</returns>
-        AccountSingle StoreAccount (Account account);
+        AccountSingle StoreAccount(Account account);
 
         /// <summary>
         /// Create new account.
@@ -170,7 +170,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="account">JSON array with the necessary account information or key&#x3D;value pairs. See the model for the exact specifications.</param>
         /// <returns>ApiResponse of AccountSingle</returns>
-        ApiResponse<AccountSingle> StoreAccountWithHttpInfo (Account account);
+        ApiResponse<AccountSingle> StoreAccountWithHttpInfo(Account account);
         /// <summary>
         /// Update existing account.
         /// </summary>
@@ -181,7 +181,7 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="account">JSON array or formdata with updated account information. See the model for the exact specifications.</param>
         /// <returns>AccountSingle</returns>
-        AccountSingle UpdateAccount (int id, Account account);
+        AccountSingle UpdateAccount(int id, Account account);
 
         /// <summary>
         /// Update existing account.
@@ -193,7 +193,7 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="account">JSON array or formdata with updated account information. See the model for the exact specifications.</param>
         /// <returns>ApiResponse of AccountSingle</returns>
-        ApiResponse<AccountSingle> UpdateAccountWithHttpInfo (int id, Account account);
+        ApiResponse<AccountSingle> UpdateAccountWithHttpInfo(int id, Account account);
         #endregion Synchronous Operations
     }
 
@@ -212,7 +212,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="id">The ID of the account.</param>
         /// <returns>Task of void</returns>
-        System.Threading.Tasks.Task DeleteAccountAsync (int id);
+        System.Threading.Tasks.Task DeleteAccountAsync(int id);
 
         /// <summary>
         /// Permanently delete account.
@@ -223,7 +223,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="id">The ID of the account.</param>
         /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse<Object>> DeleteAccountAsyncWithHttpInfo (int id);
+        System.Threading.Tasks.Task<ApiResponse<Object>> DeleteAccountAsyncWithHttpInfo(int id);
         /// <summary>
         /// Get single account.
         /// </summary>
@@ -234,7 +234,7 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <returns>Task of AccountSingle</returns>
-        System.Threading.Tasks.Task<AccountSingle> GetAccountAsync (int id, DateTime? date = default(DateTime?));
+        System.Threading.Tasks.Task<AccountSingle> GetAccountAsync(int id, DateTime? date = default(DateTime?));
 
         /// <summary>
         /// Get single account.
@@ -246,7 +246,7 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <returns>Task of ApiResponse (AccountSingle)</returns>
-        System.Threading.Tasks.Task<ApiResponse<AccountSingle>> GetAccountAsyncWithHttpInfo (int id, DateTime? date = default(DateTime?));
+        System.Threading.Tasks.Task<ApiResponse<AccountSingle>> GetAccountAsyncWithHttpInfo(int id, DateTime? date = default(DateTime?));
         /// <summary>
         /// List all accounts.
         /// </summary>
@@ -258,7 +258,7 @@ namespace FireflyIII.Api
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <param name="type">Optional filter on the account type(s) returned (optional)</param>
         /// <returns>Task of AccountArray</returns>
-        System.Threading.Tasks.Task<AccountArray> ListAccountAsync (int? page = default(int?), DateTime? date = default(DateTime?), AccountTypeFilter type = default(AccountTypeFilter));
+        System.Threading.Tasks.Task<AccountArray> ListAccountAsync(int? page = default(int?), DateTime? date = default(DateTime?), AccountTypeFilter type = default(AccountTypeFilter));
 
         /// <summary>
         /// List all accounts.
@@ -271,7 +271,7 @@ namespace FireflyIII.Api
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <param name="type">Optional filter on the account type(s) returned (optional)</param>
         /// <returns>Task of ApiResponse (AccountArray)</returns>
-        System.Threading.Tasks.Task<ApiResponse<AccountArray>> ListAccountAsyncWithHttpInfo (int? page = default(int?), DateTime? date = default(DateTime?), AccountTypeFilter type = default(AccountTypeFilter));
+        System.Threading.Tasks.Task<ApiResponse<AccountArray>> ListAccountAsyncWithHttpInfo(int? page = default(int?), DateTime? date = default(DateTime?), AccountTypeFilter type = default(AccountTypeFilter));
         /// <summary>
         /// List all piggy banks related to the account.
         /// </summary>
@@ -282,7 +282,7 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="page">Page number. The default pagination is per 50 items. (optional)</param>
         /// <returns>Task of PiggyBankArray</returns>
-        System.Threading.Tasks.Task<PiggyBankArray> ListPiggyBankByAccountAsync (int id, int? page = default(int?));
+        System.Threading.Tasks.Task<PiggyBankArray> ListPiggyBankByAccountAsync(int id, int? page = default(int?));
 
         /// <summary>
         /// List all piggy banks related to the account.
@@ -294,7 +294,7 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="page">Page number. The default pagination is per 50 items. (optional)</param>
         /// <returns>Task of ApiResponse (PiggyBankArray)</returns>
-        System.Threading.Tasks.Task<ApiResponse<PiggyBankArray>> ListPiggyBankByAccountAsyncWithHttpInfo (int id, int? page = default(int?));
+        System.Threading.Tasks.Task<ApiResponse<PiggyBankArray>> ListPiggyBankByAccountAsyncWithHttpInfo(int id, int? page = default(int?));
         /// <summary>
         /// List all transactions related to the account.
         /// </summary>
@@ -309,7 +309,7 @@ namespace FireflyIII.Api
         /// <param name="end">A date formatted YYYY-MM-DD.  (optional)</param>
         /// <param name="type">Optional filter on the transaction type(s) returned. (optional)</param>
         /// <returns>Task of TransactionArray</returns>
-        System.Threading.Tasks.Task<TransactionArray> ListTransactionByAccountAsync (int id, int? page = default(int?), int? limit = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter));
+        System.Threading.Tasks.Task<TransactionArray> ListTransactionByAccountAsync(int id, int? page = default(int?), int? limit = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter));
 
         /// <summary>
         /// List all transactions related to the account.
@@ -325,7 +325,7 @@ namespace FireflyIII.Api
         /// <param name="end">A date formatted YYYY-MM-DD.  (optional)</param>
         /// <param name="type">Optional filter on the transaction type(s) returned. (optional)</param>
         /// <returns>Task of ApiResponse (TransactionArray)</returns>
-        System.Threading.Tasks.Task<ApiResponse<TransactionArray>> ListTransactionByAccountAsyncWithHttpInfo (int id, int? page = default(int?), int? limit = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter));
+        System.Threading.Tasks.Task<ApiResponse<TransactionArray>> ListTransactionByAccountAsyncWithHttpInfo(int id, int? page = default(int?), int? limit = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter));
         /// <summary>
         /// Create new account.
         /// </summary>
@@ -335,7 +335,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="account">JSON array with the necessary account information or key&#x3D;value pairs. See the model for the exact specifications.</param>
         /// <returns>Task of AccountSingle</returns>
-        System.Threading.Tasks.Task<AccountSingle> StoreAccountAsync (Account account);
+        System.Threading.Tasks.Task<AccountSingle> StoreAccountAsync(Account account);
 
         /// <summary>
         /// Create new account.
@@ -346,7 +346,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="account">JSON array with the necessary account information or key&#x3D;value pairs. See the model for the exact specifications.</param>
         /// <returns>Task of ApiResponse (AccountSingle)</returns>
-        System.Threading.Tasks.Task<ApiResponse<AccountSingle>> StoreAccountAsyncWithHttpInfo (Account account);
+        System.Threading.Tasks.Task<ApiResponse<AccountSingle>> StoreAccountAsyncWithHttpInfo(Account account);
         /// <summary>
         /// Update existing account.
         /// </summary>
@@ -357,7 +357,7 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="account">JSON array or formdata with updated account information. See the model for the exact specifications.</param>
         /// <returns>Task of AccountSingle</returns>
-        System.Threading.Tasks.Task<AccountSingle> UpdateAccountAsync (int id, Account account);
+        System.Threading.Tasks.Task<AccountSingle> UpdateAccountAsync(int id, Account account);
 
         /// <summary>
         /// Update existing account.
@@ -369,7 +369,7 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="account">JSON array or formdata with updated account information. See the model for the exact specifications.</param>
         /// <returns>Task of ApiResponse (AccountSingle)</returns>
-        System.Threading.Tasks.Task<ApiResponse<AccountSingle>> UpdateAccountAsyncWithHttpInfo (int id, Account account);
+        System.Threading.Tasks.Task<ApiResponse<AccountSingle>> UpdateAccountAsyncWithHttpInfo(int id, Account account);
         #endregion Asynchronous Operations
     }
 
@@ -392,7 +392,7 @@ namespace FireflyIII.Api
         /// Initializes a new instance of the <see cref="AccountsApi"/> class.
         /// </summary>
         /// <returns></returns>
-        public AccountsApi() : this((string) null)
+        public AccountsApi() : this((string)null)
         {
         }
 
@@ -437,11 +437,11 @@ namespace FireflyIII.Api
         /// <param name="client">The client interface for synchronous API access.</param>
         /// <param name="asyncClient">The client interface for asynchronous API access.</param>
         /// <param name="configuration">The configuration object.</param>
-        public AccountsApi(FireflyIII.Client.ISynchronousClient client,FireflyIII.Client.IAsynchronousClient asyncClient, FireflyIII.Client.IReadableConfiguration configuration)
+        public AccountsApi(FireflyIII.Client.ISynchronousClient client, FireflyIII.Client.IAsynchronousClient asyncClient, FireflyIII.Client.IReadableConfiguration configuration)
         {
-            if(client == null) throw new ArgumentNullException("client");
-            if(asyncClient == null) throw new ArgumentNullException("asyncClient");
-            if(configuration == null) throw new ArgumentNullException("configuration");
+            if (client == null) throw new ArgumentNullException("client");
+            if (asyncClient == null) throw new ArgumentNullException("asyncClient");
+            if (configuration == null) throw new ArgumentNullException("configuration");
 
             this.Client = client;
             this.AsynchronousClient = asyncClient;
@@ -472,7 +472,7 @@ namespace FireflyIII.Api
         /// Gets or sets the configuration object
         /// </summary>
         /// <value>An instance of the Configuration</value>
-        public FireflyIII.Client.IReadableConfiguration Configuration {get; set;}
+        public FireflyIII.Client.IReadableConfiguration Configuration { get; set; }
 
         /// <summary>
         /// Provides a factory method hook for the creation of exceptions.
@@ -496,9 +496,9 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="id">The ID of the account.</param>
         /// <returns></returns>
-        public void DeleteAccount (int id)
+        public void DeleteAccount(int id)
         {
-             DeleteAccountWithHttpInfo(id);
+            DeleteAccountWithHttpInfo(id);
         }
 
         /// <summary>
@@ -507,10 +507,10 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="id">The ID of the account.</param>
         /// <returns>ApiResponse of Object(void)</returns>
-        public FireflyIII.Client.ApiResponse<Object> DeleteAccountWithHttpInfo (int id)
+        public FireflyIII.Client.ApiResponse<Object> DeleteAccountWithHttpInfo(int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AccountsApi->DeleteAccount");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -528,8 +528,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
-                localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
+            localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
             // oauth required
@@ -556,9 +555,9 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="id">The ID of the account.</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteAccountAsync (int id)
+        public async System.Threading.Tasks.Task DeleteAccountAsync(int id)
         {
-             await DeleteAccountAsyncWithHttpInfo(id);
+            await DeleteAccountAsyncWithHttpInfo(id);
 
         }
 
@@ -568,10 +567,10 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="id">The ID of the account.</param>
         /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<Object>> DeleteAccountAsyncWithHttpInfo (int id)
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<Object>> DeleteAccountAsyncWithHttpInfo(int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AccountsApi->DeleteAccount");
 
 
@@ -583,14 +582,14 @@ namespace FireflyIII.Api
             // to determine the Accept header
             String[] _accepts = new String[] {
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
+
             
-            if (id != null)
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -620,10 +619,10 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <returns>AccountSingle</returns>
-        public AccountSingle GetAccount (int id, DateTime? date = default(DateTime?))
+        public AccountSingle GetAccount(int id, DateTime? date = default(DateTime?))
         {
-             FireflyIII.Client.ApiResponse<AccountSingle> localVarResponse = GetAccountWithHttpInfo(id, date);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<AccountSingle> localVarResponse = GetAccountWithHttpInfo(id, date);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -633,10 +632,10 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <returns>ApiResponse of AccountSingle</returns>
-        public FireflyIII.Client.ApiResponse< AccountSingle > GetAccountWithHttpInfo (int id, DateTime? date = default(DateTime?))
+        public FireflyIII.Client.ApiResponse<AccountSingle> GetAccountWithHttpInfo(int id, DateTime? date = default(DateTime?))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AccountsApi->GetAccount");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -655,7 +654,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (date != null)
             {
@@ -676,7 +675,7 @@ namespace FireflyIII.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get< AccountSingle >("/api/v1/accounts/{id}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<AccountSingle>("/api/v1/accounts/{id}", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -694,10 +693,10 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <returns>Task of AccountSingle</returns>
-        public async System.Threading.Tasks.Task<AccountSingle> GetAccountAsync (int id, DateTime? date = default(DateTime?))
+        public async System.Threading.Tasks.Task<AccountSingle> GetAccountAsync(int id, DateTime? date = default(DateTime?))
         {
-             FireflyIII.Client.ApiResponse<AccountSingle> localVarResponse = await GetAccountAsyncWithHttpInfo(id, date);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<AccountSingle> localVarResponse = await GetAccountAsyncWithHttpInfo(id, date);
+            return localVarResponse.Data;
 
         }
 
@@ -708,10 +707,10 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <returns>Task of ApiResponse (AccountSingle)</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<AccountSingle>> GetAccountAsyncWithHttpInfo (int id, DateTime? date = default(DateTime?))
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<AccountSingle>> GetAccountAsyncWithHttpInfo(int id, DateTime? date = default(DateTime?))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AccountsApi->GetAccount");
 
 
@@ -724,14 +723,14 @@ namespace FireflyIII.Api
             String[] _accepts = new String[] {
                 "application/json"
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
+
             
-            if (id != null)
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (date != null)
             {
@@ -772,10 +771,10 @@ namespace FireflyIII.Api
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <param name="type">Optional filter on the account type(s) returned (optional)</param>
         /// <returns>AccountArray</returns>
-        public AccountArray ListAccount (int? page = default(int?), DateTime? date = default(DateTime?), AccountTypeFilter type = default(AccountTypeFilter))
+        public AccountArray ListAccount(int? page = default(int?), DateTime? date = default(DateTime?), AccountTypeFilter type = default(AccountTypeFilter))
         {
-             FireflyIII.Client.ApiResponse<AccountArray> localVarResponse = ListAccountWithHttpInfo(page, date, type);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<AccountArray> localVarResponse = ListAccountWithHttpInfo(page, date, type);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -786,7 +785,7 @@ namespace FireflyIII.Api
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <param name="type">Optional filter on the account type(s) returned (optional)</param>
         /// <returns>ApiResponse of AccountArray</returns>
-        public FireflyIII.Client.ApiResponse< AccountArray > ListAccountWithHttpInfo (int? page = default(int?), DateTime? date = default(DateTime?), AccountTypeFilter type = default(AccountTypeFilter))
+        public FireflyIII.Client.ApiResponse<AccountArray> ListAccountWithHttpInfo(int? page = default(int?), DateTime? date = default(DateTime?), AccountTypeFilter type = default(AccountTypeFilter))
         {
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
 
@@ -824,7 +823,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -843,7 +842,7 @@ namespace FireflyIII.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get< AccountArray >("/api/v1/accounts", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<AccountArray>("/api/v1/accounts", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -862,10 +861,10 @@ namespace FireflyIII.Api
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <param name="type">Optional filter on the account type(s) returned (optional)</param>
         /// <returns>Task of AccountArray</returns>
-        public async System.Threading.Tasks.Task<AccountArray> ListAccountAsync (int? page = default(int?), DateTime? date = default(DateTime?), AccountTypeFilter type = default(AccountTypeFilter))
+        public async System.Threading.Tasks.Task<AccountArray> ListAccountAsync(int? page = default(int?), DateTime? date = default(DateTime?), AccountTypeFilter type = default(AccountTypeFilter))
         {
-             FireflyIII.Client.ApiResponse<AccountArray> localVarResponse = await ListAccountAsyncWithHttpInfo(page, date, type);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<AccountArray> localVarResponse = await ListAccountAsyncWithHttpInfo(page, date, type);
+            return localVarResponse.Data;
 
         }
 
@@ -877,7 +876,7 @@ namespace FireflyIII.Api
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <param name="type">Optional filter on the account type(s) returned (optional)</param>
         /// <returns>Task of ApiResponse (AccountArray)</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<AccountArray>> ListAccountAsyncWithHttpInfo (int? page = default(int?), DateTime? date = default(DateTime?), AccountTypeFilter type = default(AccountTypeFilter))
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<AccountArray>> ListAccountAsyncWithHttpInfo(int? page = default(int?), DateTime? date = default(DateTime?), AccountTypeFilter type = default(AccountTypeFilter))
         {
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -889,13 +888,13 @@ namespace FireflyIII.Api
             String[] _accepts = new String[] {
                 "application/json"
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
-            
+
             if (page != null)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "page", page))
@@ -916,7 +915,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -954,10 +953,10 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="page">Page number. The default pagination is per 50 items. (optional)</param>
         /// <returns>PiggyBankArray</returns>
-        public PiggyBankArray ListPiggyBankByAccount (int id, int? page = default(int?))
+        public PiggyBankArray ListPiggyBankByAccount(int id, int? page = default(int?))
         {
-             FireflyIII.Client.ApiResponse<PiggyBankArray> localVarResponse = ListPiggyBankByAccountWithHttpInfo(id, page);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<PiggyBankArray> localVarResponse = ListPiggyBankByAccountWithHttpInfo(id, page);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -967,10 +966,10 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="page">Page number. The default pagination is per 50 items. (optional)</param>
         /// <returns>ApiResponse of PiggyBankArray</returns>
-        public FireflyIII.Client.ApiResponse< PiggyBankArray > ListPiggyBankByAccountWithHttpInfo (int id, int? page = default(int?))
+        public FireflyIII.Client.ApiResponse<PiggyBankArray> ListPiggyBankByAccountWithHttpInfo(int id, int? page = default(int?))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AccountsApi->ListPiggyBankByAccount");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -989,7 +988,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -1010,7 +1009,7 @@ namespace FireflyIII.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get< PiggyBankArray >("/api/v1/accounts/{id}/piggy_banks", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<PiggyBankArray>("/api/v1/accounts/{id}/piggy_banks", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1028,10 +1027,10 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="page">Page number. The default pagination is per 50 items. (optional)</param>
         /// <returns>Task of PiggyBankArray</returns>
-        public async System.Threading.Tasks.Task<PiggyBankArray> ListPiggyBankByAccountAsync (int id, int? page = default(int?))
+        public async System.Threading.Tasks.Task<PiggyBankArray> ListPiggyBankByAccountAsync(int id, int? page = default(int?))
         {
-             FireflyIII.Client.ApiResponse<PiggyBankArray> localVarResponse = await ListPiggyBankByAccountAsyncWithHttpInfo(id, page);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<PiggyBankArray> localVarResponse = await ListPiggyBankByAccountAsyncWithHttpInfo(id, page);
+            return localVarResponse.Data;
 
         }
 
@@ -1042,10 +1041,10 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="page">Page number. The default pagination is per 50 items. (optional)</param>
         /// <returns>Task of ApiResponse (PiggyBankArray)</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<PiggyBankArray>> ListPiggyBankByAccountAsyncWithHttpInfo (int id, int? page = default(int?))
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<PiggyBankArray>> ListPiggyBankByAccountAsyncWithHttpInfo(int id, int? page = default(int?))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AccountsApi->ListPiggyBankByAccount");
 
 
@@ -1058,14 +1057,14 @@ namespace FireflyIII.Api
             String[] _accepts = new String[] {
                 "application/json"
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
+
             
-            if (id != null)
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -1109,10 +1108,10 @@ namespace FireflyIII.Api
         /// <param name="end">A date formatted YYYY-MM-DD.  (optional)</param>
         /// <param name="type">Optional filter on the transaction type(s) returned. (optional)</param>
         /// <returns>TransactionArray</returns>
-        public TransactionArray ListTransactionByAccount (int id, int? page = default(int?), int? limit = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
+        public TransactionArray ListTransactionByAccount(int id, int? page = default(int?), int? limit = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
         {
-             FireflyIII.Client.ApiResponse<TransactionArray> localVarResponse = ListTransactionByAccountWithHttpInfo(id, page, limit, start, end, type);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<TransactionArray> localVarResponse = ListTransactionByAccountWithHttpInfo(id, page, limit, start, end, type);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -1126,10 +1125,10 @@ namespace FireflyIII.Api
         /// <param name="end">A date formatted YYYY-MM-DD.  (optional)</param>
         /// <param name="type">Optional filter on the transaction type(s) returned. (optional)</param>
         /// <returns>ApiResponse of TransactionArray</returns>
-        public FireflyIII.Client.ApiResponse< TransactionArray > ListTransactionByAccountWithHttpInfo (int id, int? page = default(int?), int? limit = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
+        public FireflyIII.Client.ApiResponse<TransactionArray> ListTransactionByAccountWithHttpInfo(int id, int? page = default(int?), int? limit = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AccountsApi->ListTransactionByAccount");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -1148,7 +1147,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -1190,7 +1189,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -1209,7 +1208,7 @@ namespace FireflyIII.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get< TransactionArray >("/api/v1/accounts/{id}/transactions", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<TransactionArray>("/api/v1/accounts/{id}/transactions", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1231,10 +1230,10 @@ namespace FireflyIII.Api
         /// <param name="end">A date formatted YYYY-MM-DD.  (optional)</param>
         /// <param name="type">Optional filter on the transaction type(s) returned. (optional)</param>
         /// <returns>Task of TransactionArray</returns>
-        public async System.Threading.Tasks.Task<TransactionArray> ListTransactionByAccountAsync (int id, int? page = default(int?), int? limit = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
+        public async System.Threading.Tasks.Task<TransactionArray> ListTransactionByAccountAsync(int id, int? page = default(int?), int? limit = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
         {
-             FireflyIII.Client.ApiResponse<TransactionArray> localVarResponse = await ListTransactionByAccountAsyncWithHttpInfo(id, page, limit, start, end, type);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<TransactionArray> localVarResponse = await ListTransactionByAccountAsyncWithHttpInfo(id, page, limit, start, end, type);
+            return localVarResponse.Data;
 
         }
 
@@ -1249,10 +1248,10 @@ namespace FireflyIII.Api
         /// <param name="end">A date formatted YYYY-MM-DD.  (optional)</param>
         /// <param name="type">Optional filter on the transaction type(s) returned. (optional)</param>
         /// <returns>Task of ApiResponse (TransactionArray)</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<TransactionArray>> ListTransactionByAccountAsyncWithHttpInfo (int id, int? page = default(int?), int? limit = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<TransactionArray>> ListTransactionByAccountAsyncWithHttpInfo(int id, int? page = default(int?), int? limit = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AccountsApi->ListTransactionByAccount");
 
 
@@ -1265,14 +1264,14 @@ namespace FireflyIII.Api
             String[] _accepts = new String[] {
                 "application/json"
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
+
             
-            if (id != null)
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -1314,7 +1313,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -1351,10 +1350,10 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="account">JSON array with the necessary account information or key&#x3D;value pairs. See the model for the exact specifications.</param>
         /// <returns>AccountSingle</returns>
-        public AccountSingle StoreAccount (Account account)
+        public AccountSingle StoreAccount(Account account)
         {
-             FireflyIII.Client.ApiResponse<AccountSingle> localVarResponse = StoreAccountWithHttpInfo(account);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<AccountSingle> localVarResponse = StoreAccountWithHttpInfo(account);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -1363,7 +1362,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="account">JSON array with the necessary account information or key&#x3D;value pairs. See the model for the exact specifications.</param>
         /// <returns>ApiResponse of AccountSingle</returns>
-        public FireflyIII.Client.ApiResponse< AccountSingle > StoreAccountWithHttpInfo (Account account)
+        public FireflyIII.Client.ApiResponse<AccountSingle> StoreAccountWithHttpInfo(Account account)
         {
             // verify the required parameter 'account' is set
             if (account == null)
@@ -1372,7 +1371,7 @@ namespace FireflyIII.Api
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
 
             String[] _contentTypes = new String[] {
-                "application/json", 
+                "application/json",
                 "application/x-www-form-urlencoded"
             };
 
@@ -1397,7 +1396,7 @@ namespace FireflyIII.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post< AccountSingle >("/api/v1/accounts", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<AccountSingle>("/api/v1/accounts", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1414,10 +1413,10 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="account">JSON array with the necessary account information or key&#x3D;value pairs. See the model for the exact specifications.</param>
         /// <returns>Task of AccountSingle</returns>
-        public async System.Threading.Tasks.Task<AccountSingle> StoreAccountAsync (Account account)
+        public async System.Threading.Tasks.Task<AccountSingle> StoreAccountAsync(Account account)
         {
-             FireflyIII.Client.ApiResponse<AccountSingle> localVarResponse = await StoreAccountAsyncWithHttpInfo(account);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<AccountSingle> localVarResponse = await StoreAccountAsyncWithHttpInfo(account);
+            return localVarResponse.Data;
 
         }
 
@@ -1427,7 +1426,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="account">JSON array with the necessary account information or key&#x3D;value pairs. See the model for the exact specifications.</param>
         /// <returns>Task of ApiResponse (AccountSingle)</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<AccountSingle>> StoreAccountAsyncWithHttpInfo (Account account)
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<AccountSingle>> StoreAccountAsyncWithHttpInfo(Account account)
         {
             // verify the required parameter 'account' is set
             if (account == null)
@@ -1437,7 +1436,7 @@ namespace FireflyIII.Api
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
 
             String[] _contentTypes = new String[] {
-                "application/json", 
+                "application/json",
                 "application/x-www-form-urlencoded"
             };
 
@@ -1445,13 +1444,13 @@ namespace FireflyIII.Api
             String[] _accepts = new String[] {
                 "application/json"
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
-            
+
             localVarRequestOptions.Data = account;
 
             // authentication (firefly_iii_auth) required
@@ -1481,10 +1480,10 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="account">JSON array or formdata with updated account information. See the model for the exact specifications.</param>
         /// <returns>AccountSingle</returns>
-        public AccountSingle UpdateAccount (int id, Account account)
+        public AccountSingle UpdateAccount(int id, Account account)
         {
-             FireflyIII.Client.ApiResponse<AccountSingle> localVarResponse = UpdateAccountWithHttpInfo(id, account);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<AccountSingle> localVarResponse = UpdateAccountWithHttpInfo(id, account);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -1494,10 +1493,10 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="account">JSON array or formdata with updated account information. See the model for the exact specifications.</param>
         /// <returns>ApiResponse of AccountSingle</returns>
-        public FireflyIII.Client.ApiResponse< AccountSingle > UpdateAccountWithHttpInfo (int id, Account account)
+        public FireflyIII.Client.ApiResponse<AccountSingle> UpdateAccountWithHttpInfo(int id, Account account)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AccountsApi->UpdateAccount");
 
             // verify the required parameter 'account' is set
@@ -1507,7 +1506,7 @@ namespace FireflyIII.Api
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
 
             String[] _contentTypes = new String[] {
-                "application/json", 
+                "application/json",
                 "application/x-www-form-urlencoded"
             };
 
@@ -1522,8 +1521,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
-                localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
+            localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = account;
 
             // authentication (firefly_iii_auth) required
@@ -1534,7 +1532,7 @@ namespace FireflyIII.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Put< AccountSingle >("/api/v1/accounts/{id}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Put<AccountSingle>("/api/v1/accounts/{id}", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1552,10 +1550,10 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="account">JSON array or formdata with updated account information. See the model for the exact specifications.</param>
         /// <returns>Task of AccountSingle</returns>
-        public async System.Threading.Tasks.Task<AccountSingle> UpdateAccountAsync (int id, Account account)
+        public async System.Threading.Tasks.Task<AccountSingle> UpdateAccountAsync(int id, Account account)
         {
-             FireflyIII.Client.ApiResponse<AccountSingle> localVarResponse = await UpdateAccountAsyncWithHttpInfo(id, account);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<AccountSingle> localVarResponse = await UpdateAccountAsyncWithHttpInfo(id, account);
+            return localVarResponse.Data;
 
         }
 
@@ -1566,10 +1564,10 @@ namespace FireflyIII.Api
         /// <param name="id">The ID of the account.</param>
         /// <param name="account">JSON array or formdata with updated account information. See the model for the exact specifications.</param>
         /// <returns>Task of ApiResponse (AccountSingle)</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<AccountSingle>> UpdateAccountAsyncWithHttpInfo (int id, Account account)
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<AccountSingle>> UpdateAccountAsyncWithHttpInfo(int id, Account account)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AccountsApi->UpdateAccount");
 
             // verify the required parameter 'account' is set
@@ -1580,7 +1578,7 @@ namespace FireflyIII.Api
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
 
             String[] _contentTypes = new String[] {
-                "application/json", 
+                "application/json",
                 "application/x-www-form-urlencoded"
             };
 
@@ -1588,15 +1586,14 @@ namespace FireflyIII.Api
             String[] _accepts = new String[] {
                 "application/json"
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
-            
-            if (id != null)
-                localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
+
+            localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = account;
 
             // authentication (firefly_iii_auth) required

--- a/generated/src/FireflyIII/Api/AttachmentsApi.cs
+++ b/generated/src/FireflyIII/Api/AttachmentsApi.cs
@@ -478,7 +478,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse<Object> DeleteAttachmentWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AttachmentsApi->DeleteAttachment");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -496,7 +496,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -539,7 +539,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<Object>> DeleteAttachmentAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AttachmentsApi->DeleteAttachment");
 
 
@@ -558,7 +558,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -602,7 +602,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< System.IO.Stream > DownloadAttachmentWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AttachmentsApi->DownloadAttachment");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -621,7 +621,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -665,7 +665,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<System.IO.Stream>> DownloadAttachmentAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AttachmentsApi->DownloadAttachment");
 
 
@@ -685,7 +685,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -729,7 +729,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< AttachmentSingle > GetAttachmentWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AttachmentsApi->GetAttachment");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -748,7 +748,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -792,7 +792,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<AttachmentSingle>> GetAttachmentAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AttachmentsApi->GetAttachment");
 
 
@@ -812,7 +812,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -1122,7 +1122,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< AttachmentSingle > UpdateAttachmentWithHttpInfo (int id, Attachment attachment)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AttachmentsApi->UpdateAttachment");
 
             // verify the required parameter 'attachment' is set
@@ -1147,7 +1147,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = attachment;
 
@@ -1194,7 +1194,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<AttachmentSingle>> UpdateAttachmentAsyncWithHttpInfo (int id, Attachment attachment)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AttachmentsApi->UpdateAttachment");
 
             // verify the required parameter 'attachment' is set
@@ -1220,7 +1220,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = attachment;
 
@@ -1266,7 +1266,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse<Object> UploadAttachmentWithHttpInfo (int id, System.IO.Stream body = default(System.IO.Stream))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AttachmentsApi->UploadAttachment");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -1285,7 +1285,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = body;
 
@@ -1331,7 +1331,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<Object>> UploadAttachmentAsyncWithHttpInfo (int id, System.IO.Stream body = default(System.IO.Stream))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AttachmentsApi->UploadAttachment");
 
 
@@ -1351,7 +1351,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = body;
 

--- a/generated/src/FireflyIII/Api/AvailableBudgetsApi.cs
+++ b/generated/src/FireflyIII/Api/AvailableBudgetsApi.cs
@@ -398,7 +398,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse<Object> DeleteAvailableBudgetWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AvailableBudgetsApi->DeleteAvailableBudget");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -416,7 +416,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -459,7 +459,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<Object>> DeleteAvailableBudgetAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AvailableBudgetsApi->DeleteAvailableBudget");
 
 
@@ -478,7 +478,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -522,7 +522,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< AvailableBudgetSingle > GetAvailableBudgetWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AvailableBudgetsApi->GetAvailableBudget");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -541,7 +541,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -585,7 +585,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<AvailableBudgetSingle>> GetAvailableBudgetAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AvailableBudgetsApi->GetAvailableBudget");
 
 
@@ -605,7 +605,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -963,7 +963,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< AvailableBudgetSingle > UpdateAvailableBudgetWithHttpInfo (int id, AvailableBudget availableBudget)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AvailableBudgetsApi->UpdateAvailableBudget");
 
             // verify the required parameter 'availableBudget' is set
@@ -988,7 +988,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = availableBudget;
 
@@ -1035,7 +1035,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<AvailableBudgetSingle>> UpdateAvailableBudgetAsyncWithHttpInfo (int id, AvailableBudget availableBudget)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling AvailableBudgetsApi->UpdateAvailableBudget");
 
             // verify the required parameter 'availableBudget' is set
@@ -1061,7 +1061,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = availableBudget;
 

--- a/generated/src/FireflyIII/Api/BillsApi.cs
+++ b/generated/src/FireflyIII/Api/BillsApi.cs
@@ -548,7 +548,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse<Object> DeleteBillWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BillsApi->DeleteBill");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -566,7 +566,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -609,7 +609,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<Object>> DeleteBillAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BillsApi->DeleteBill");
 
 
@@ -628,7 +628,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -676,7 +676,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< BillSingle > GetBillWithHttpInfo (int id, DateTime? start = default(DateTime?), DateTime? end = default(DateTime?))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BillsApi->GetBill");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -695,7 +695,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (start != null)
             {
@@ -763,7 +763,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<BillSingle>> GetBillAsyncWithHttpInfo (int id, DateTime? start = default(DateTime?), DateTime? end = default(DateTime?))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BillsApi->GetBill");
 
 
@@ -783,7 +783,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (start != null)
             {
@@ -849,7 +849,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< AttachmentArray > ListAttachmentByBillWithHttpInfo (int id, int? page = default(int?))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BillsApi->ListAttachmentByBill");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -868,7 +868,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -924,7 +924,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<AttachmentArray>> ListAttachmentByBillAsyncWithHttpInfo (int id, int? page = default(int?))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BillsApi->ListAttachmentByBill");
 
 
@@ -944,7 +944,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -1181,7 +1181,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< RuleArray > ListRuleByBillWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BillsApi->ListRuleByBill");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -1200,7 +1200,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -1244,7 +1244,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<RuleArray>> ListRuleByBillAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BillsApi->ListRuleByBill");
 
 
@@ -1264,7 +1264,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -1314,7 +1314,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< TransactionArray > ListTransactionByBillWithHttpInfo (int id, DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BillsApi->ListTransactionByBill");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -1333,7 +1333,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (start != null)
             {
@@ -1355,7 +1355,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -1413,7 +1413,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<TransactionArray>> ListTransactionByBillAsyncWithHttpInfo (int id, DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BillsApi->ListTransactionByBill");
 
 
@@ -1433,7 +1433,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (start != null)
             {
@@ -1455,7 +1455,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -1638,7 +1638,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< BillSingle > UpdateBillWithHttpInfo (int id, Bill bill)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BillsApi->UpdateBill");
 
             // verify the required parameter 'bill' is set
@@ -1663,7 +1663,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = bill;
 
@@ -1710,7 +1710,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<BillSingle>> UpdateBillAsyncWithHttpInfo (int id, Bill bill)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BillsApi->UpdateBill");
 
             // verify the required parameter 'bill' is set
@@ -1736,7 +1736,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = bill;
 

--- a/generated/src/FireflyIII/Api/BudgetsApi.cs
+++ b/generated/src/FireflyIII/Api/BudgetsApi.cs
@@ -744,7 +744,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse<Object> DeleteBudgetWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BudgetsApi->DeleteBudget");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -762,7 +762,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -805,7 +805,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<Object>> DeleteBudgetAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BudgetsApi->DeleteBudget");
 
 
@@ -824,7 +824,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -867,7 +867,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse<Object> DeleteBudgetLimitWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BudgetsApi->DeleteBudgetLimit");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -885,7 +885,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -928,7 +928,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<Object>> DeleteBudgetLimitAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BudgetsApi->DeleteBudgetLimit");
 
 
@@ -947,7 +947,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -995,7 +995,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< BudgetSingle > GetBudgetWithHttpInfo (int id, DateTime? startDate = default(DateTime?), DateTime? endDate = default(DateTime?))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BudgetsApi->GetBudget");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -1014,7 +1014,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (startDate != null)
             {
@@ -1082,7 +1082,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<BudgetSingle>> GetBudgetAsyncWithHttpInfo (int id, DateTime? startDate = default(DateTime?), DateTime? endDate = default(DateTime?))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BudgetsApi->GetBudget");
 
 
@@ -1102,7 +1102,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (startDate != null)
             {
@@ -1166,7 +1166,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< BudgetLimitSingle > GetBudgetLimitWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BudgetsApi->GetBudgetLimit");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -1185,7 +1185,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -1229,7 +1229,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<BudgetLimitSingle>> GetBudgetLimitAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BudgetsApi->GetBudgetLimit");
 
 
@@ -1249,7 +1249,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -1480,7 +1480,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< BudgetLimitArray > ListBudgetLimitByBudgetWithHttpInfo (int id, DateTime? start = default(DateTime?), DateTime? end = default(DateTime?))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BudgetsApi->ListBudgetLimitByBudget");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -1499,7 +1499,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (start != null)
             {
@@ -1567,7 +1567,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<BudgetLimitArray>> ListBudgetLimitByBudgetAsyncWithHttpInfo (int id, DateTime? start = default(DateTime?), DateTime? end = default(DateTime?))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BudgetsApi->ListBudgetLimitByBudget");
 
 
@@ -1587,7 +1587,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (start != null)
             {
@@ -1661,7 +1661,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< TransactionArray > ListTransactionByBudgetWithHttpInfo (int id, int? limit = default(int?), int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BudgetsApi->ListTransactionByBudget");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -1680,7 +1680,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (limit != null)
             {
@@ -1722,7 +1722,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -1784,7 +1784,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<TransactionArray>> ListTransactionByBudgetAsyncWithHttpInfo (int id, int? limit = default(int?), int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BudgetsApi->ListTransactionByBudget");
 
 
@@ -1804,7 +1804,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (limit != null)
             {
@@ -1846,7 +1846,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -1902,7 +1902,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< TransactionArray > ListTransactionByBudgetLimitWithHttpInfo (int id, int? page = default(int?), TransactionTypeFilter type = default(TransactionTypeFilter))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BudgetsApi->ListTransactionByBudgetLimit");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -1921,7 +1921,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -1933,7 +1933,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -1989,7 +1989,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<TransactionArray>> ListTransactionByBudgetLimitAsyncWithHttpInfo (int id, int? page = default(int?), TransactionTypeFilter type = default(TransactionTypeFilter))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BudgetsApi->ListTransactionByBudgetLimit");
 
 
@@ -2009,7 +2009,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -2021,7 +2021,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -2204,7 +2204,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< BudgetLimitSingle > StoreBudgetLimitWithHttpInfo (int id, BudgetLimit budgetLimit)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BudgetsApi->StoreBudgetLimit");
 
             // verify the required parameter 'budgetLimit' is set
@@ -2229,7 +2229,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = budgetLimit;
 
@@ -2276,7 +2276,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<BudgetLimitSingle>> StoreBudgetLimitAsyncWithHttpInfo (int id, BudgetLimit budgetLimit)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BudgetsApi->StoreBudgetLimit");
 
             // verify the required parameter 'budgetLimit' is set
@@ -2302,7 +2302,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = budgetLimit;
 
@@ -2349,7 +2349,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< BudgetSingle > UpdateBudgetWithHttpInfo (int id, Budget budget)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BudgetsApi->UpdateBudget");
 
             // verify the required parameter 'budget' is set
@@ -2374,7 +2374,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = budget;
 
@@ -2421,7 +2421,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<BudgetSingle>> UpdateBudgetAsyncWithHttpInfo (int id, Budget budget)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BudgetsApi->UpdateBudget");
 
             // verify the required parameter 'budget' is set
@@ -2447,7 +2447,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = budget;
 
@@ -2494,7 +2494,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< BudgetLimitSingle > UpdateBudgetLimitWithHttpInfo (int id, BudgetLimit budgetLimit)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BudgetsApi->UpdateBudgetLimit");
 
             // verify the required parameter 'budgetLimit' is set
@@ -2519,7 +2519,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = budgetLimit;
 
@@ -2566,7 +2566,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<BudgetLimitSingle>> UpdateBudgetLimitAsyncWithHttpInfo (int id, BudgetLimit budgetLimit)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling BudgetsApi->UpdateBudgetLimit");
 
             // verify the required parameter 'budgetLimit' is set
@@ -2592,7 +2592,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = budgetLimit;
 

--- a/generated/src/FireflyIII/Api/CategoriesApi.cs
+++ b/generated/src/FireflyIII/Api/CategoriesApi.cs
@@ -448,7 +448,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse<Object> DeleteCategoryWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling CategoriesApi->DeleteCategory");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -466,7 +466,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -509,7 +509,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<Object>> DeleteCategoryAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling CategoriesApi->DeleteCategory");
 
 
@@ -528,7 +528,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -572,7 +572,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< CategorySingle > GetCategoryWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling CategoriesApi->GetCategory");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -591,7 +591,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -635,7 +635,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<CategorySingle>> GetCategoryAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling CategoriesApi->GetCategory");
 
 
@@ -655,7 +655,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -842,7 +842,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< TransactionArray > ListTransactionByCategoryWithHttpInfo (int id, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling CategoriesApi->ListTransactionByCategory");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -861,7 +861,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -893,7 +893,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -953,7 +953,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<TransactionArray>> ListTransactionByCategoryAsyncWithHttpInfo (int id, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling CategoriesApi->ListTransactionByCategory");
 
 
@@ -973,7 +973,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -1005,7 +1005,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -1188,7 +1188,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< CategorySingle > UpdateCategoryWithHttpInfo (int id, Category category)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling CategoriesApi->UpdateCategory");
 
             // verify the required parameter 'category' is set
@@ -1213,7 +1213,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = category;
 
@@ -1260,7 +1260,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<CategorySingle>> UpdateCategoryAsyncWithHttpInfo (int id, Category category)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling CategoriesApi->UpdateCategory");
 
             // verify the required parameter 'category' is set
@@ -1286,7 +1286,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = category;
 

--- a/generated/src/FireflyIII/Api/ChartsApi.cs
+++ b/generated/src/FireflyIII/Api/ChartsApi.cs
@@ -415,7 +415,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< List<ChartDataSet> > GetChartABOverviewWithHttpInfo (int id, DateTime start, DateTime end)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling ChartsApi->GetChartABOverview");
 
             // verify the required parameter 'start' is set
@@ -442,7 +442,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (start != null)
             {
@@ -510,7 +510,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<List<ChartDataSet>>> GetChartABOverviewAsyncWithHttpInfo (int id, DateTime start, DateTime end)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling ChartsApi->GetChartABOverview");
 
             // verify the required parameter 'start' is set
@@ -538,7 +538,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (start != null)
             {

--- a/generated/src/FireflyIII/Api/CurrenciesApi.cs
+++ b/generated/src/FireflyIII/Api/CurrenciesApi.cs
@@ -36,7 +36,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>CurrencySingle</returns>
-        CurrencySingle DefaultCurrency (string code);
+        CurrencySingle DefaultCurrency(string code);
 
         /// <summary>
         /// Make currency default currency.
@@ -47,7 +47,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>ApiResponse of CurrencySingle</returns>
-        ApiResponse<CurrencySingle> DefaultCurrencyWithHttpInfo (string code);
+        ApiResponse<CurrencySingle> DefaultCurrencyWithHttpInfo(string code);
         /// <summary>
         /// Delete a currency.
         /// </summary>
@@ -57,7 +57,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns></returns>
-        void DeleteCurrency (string code);
+        void DeleteCurrency(string code);
 
         /// <summary>
         /// Delete a currency.
@@ -68,7 +68,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>ApiResponse of Object(void)</returns>
-        ApiResponse<Object> DeleteCurrencyWithHttpInfo (string code);
+        ApiResponse<Object> DeleteCurrencyWithHttpInfo(string code);
         /// <summary>
         /// Disable a currency.
         /// </summary>
@@ -78,7 +78,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>CurrencySingle</returns>
-        CurrencySingle DisableCurrency (int code);
+        CurrencySingle DisableCurrency(int code);
 
         /// <summary>
         /// Disable a currency.
@@ -89,7 +89,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>ApiResponse of CurrencySingle</returns>
-        ApiResponse<CurrencySingle> DisableCurrencyWithHttpInfo (int code);
+        ApiResponse<CurrencySingle> DisableCurrencyWithHttpInfo(int code);
         /// <summary>
         /// Enable a single currency.
         /// </summary>
@@ -99,7 +99,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>CurrencySingle</returns>
-        CurrencySingle EnableCurrency (string code);
+        CurrencySingle EnableCurrency(string code);
 
         /// <summary>
         /// Enable a single currency.
@@ -110,7 +110,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>ApiResponse of CurrencySingle</returns>
-        ApiResponse<CurrencySingle> EnableCurrencyWithHttpInfo (string code);
+        ApiResponse<CurrencySingle> EnableCurrencyWithHttpInfo(string code);
         /// <summary>
         /// Get a single currency.
         /// </summary>
@@ -120,7 +120,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>CurrencySingle</returns>
-        CurrencySingle GetCurrency (string code);
+        CurrencySingle GetCurrency(string code);
 
         /// <summary>
         /// Get a single currency.
@@ -131,7 +131,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>ApiResponse of CurrencySingle</returns>
-        ApiResponse<CurrencySingle> GetCurrencyWithHttpInfo (string code);
+        ApiResponse<CurrencySingle> GetCurrencyWithHttpInfo(string code);
         /// <summary>
         /// List all accounts with this currency.
         /// </summary>
@@ -144,7 +144,7 @@ namespace FireflyIII.Api
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <param name="type">Optional filter on the account type(s) returned (optional)</param>
         /// <returns>AccountArray</returns>
-        AccountArray ListAccountByCurrency (string code, int? page = default(int?), string date = default(string), AccountTypeFilter type = default(AccountTypeFilter));
+        AccountArray ListAccountByCurrency(string code, int? page = default(int?), string date = default(string), AccountTypeFilter type = default(AccountTypeFilter));
 
         /// <summary>
         /// List all accounts with this currency.
@@ -158,7 +158,7 @@ namespace FireflyIII.Api
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <param name="type">Optional filter on the account type(s) returned (optional)</param>
         /// <returns>ApiResponse of AccountArray</returns>
-        ApiResponse<AccountArray> ListAccountByCurrencyWithHttpInfo (string code, int? page = default(int?), string date = default(string), AccountTypeFilter type = default(AccountTypeFilter));
+        ApiResponse<AccountArray> ListAccountByCurrencyWithHttpInfo(string code, int? page = default(int?), string date = default(string), AccountTypeFilter type = default(AccountTypeFilter));
         /// <summary>
         /// List all available budgets with this currency.
         /// </summary>
@@ -169,7 +169,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50 (optional)</param>
         /// <returns>AvailableBudgetArray</returns>
-        AvailableBudgetArray ListAvailableBudgetByCurrency (string code, int? page = default(int?));
+        AvailableBudgetArray ListAvailableBudgetByCurrency(string code, int? page = default(int?));
 
         /// <summary>
         /// List all available budgets with this currency.
@@ -181,7 +181,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50 (optional)</param>
         /// <returns>ApiResponse of AvailableBudgetArray</returns>
-        ApiResponse<AvailableBudgetArray> ListAvailableBudgetByCurrencyWithHttpInfo (string code, int? page = default(int?));
+        ApiResponse<AvailableBudgetArray> ListAvailableBudgetByCurrencyWithHttpInfo(string code, int? page = default(int?));
         /// <summary>
         /// List all bills with this currency.
         /// </summary>
@@ -192,7 +192,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>BillArray</returns>
-        BillArray ListBillByCurrency (string code, int? page = default(int?));
+        BillArray ListBillByCurrency(string code, int? page = default(int?));
 
         /// <summary>
         /// List all bills with this currency.
@@ -204,7 +204,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>ApiResponse of BillArray</returns>
-        ApiResponse<BillArray> ListBillByCurrencyWithHttpInfo (string code, int? page = default(int?));
+        ApiResponse<BillArray> ListBillByCurrencyWithHttpInfo(string code, int? page = default(int?));
         /// <summary>
         /// List all budget limits with this currency
         /// </summary>
@@ -217,7 +217,7 @@ namespace FireflyIII.Api
         /// <param name="start">Start date for the budget limit list. (optional)</param>
         /// <param name="end">End date for the budget limit list. (optional)</param>
         /// <returns>BudgetLimitArray</returns>
-        BudgetLimitArray ListBudgetLimitByCurrency (string code, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?));
+        BudgetLimitArray ListBudgetLimitByCurrency(string code, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?));
 
         /// <summary>
         /// List all budget limits with this currency
@@ -231,7 +231,7 @@ namespace FireflyIII.Api
         /// <param name="start">Start date for the budget limit list. (optional)</param>
         /// <param name="end">End date for the budget limit list. (optional)</param>
         /// <returns>ApiResponse of BudgetLimitArray</returns>
-        ApiResponse<BudgetLimitArray> ListBudgetLimitByCurrencyWithHttpInfo (string code, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?));
+        ApiResponse<BudgetLimitArray> ListBudgetLimitByCurrencyWithHttpInfo(string code, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?));
         /// <summary>
         /// List all currencies.
         /// </summary>
@@ -241,7 +241,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>CurrencyArray</returns>
-        CurrencyArray ListCurrency (int? page = default(int?));
+        CurrencyArray ListCurrency(int? page = default(int?));
 
         /// <summary>
         /// List all currencies.
@@ -252,7 +252,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>ApiResponse of CurrencyArray</returns>
-        ApiResponse<CurrencyArray> ListCurrencyWithHttpInfo (int? page = default(int?));
+        ApiResponse<CurrencyArray> ListCurrencyWithHttpInfo(int? page = default(int?));
         /// <summary>
         /// List all known exchange rates with (from or to) this currency.
         /// </summary>
@@ -266,7 +266,7 @@ namespace FireflyIII.Api
         /// <param name="start">Use this instead of the date parameter to search for a range of currency exchange values.  (optional)</param>
         /// <param name="end">Use this instead of the date parameter to search for a range of currency exchange values.  (optional)</param>
         /// <returns>ExchangeRateArray</returns>
-        ExchangeRateArray ListExchangeRateByCurrency (string code, int? page = default(int?), DateTime? date = default(DateTime?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?));
+        ExchangeRateArray ListExchangeRateByCurrency(string code, int? page = default(int?), DateTime? date = default(DateTime?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?));
 
         /// <summary>
         /// List all known exchange rates with (from or to) this currency.
@@ -281,7 +281,7 @@ namespace FireflyIII.Api
         /// <param name="start">Use this instead of the date parameter to search for a range of currency exchange values.  (optional)</param>
         /// <param name="end">Use this instead of the date parameter to search for a range of currency exchange values.  (optional)</param>
         /// <returns>ApiResponse of ExchangeRateArray</returns>
-        ApiResponse<ExchangeRateArray> ListExchangeRateByCurrencyWithHttpInfo (string code, int? page = default(int?), DateTime? date = default(DateTime?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?));
+        ApiResponse<ExchangeRateArray> ListExchangeRateByCurrencyWithHttpInfo(string code, int? page = default(int?), DateTime? date = default(DateTime?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?));
         /// <summary>
         /// List all recurring transactions with this currency.
         /// </summary>
@@ -292,7 +292,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>RecurrenceArray</returns>
-        RecurrenceArray ListRecurrenceByCurrency (string code, int? page = default(int?));
+        RecurrenceArray ListRecurrenceByCurrency(string code, int? page = default(int?));
 
         /// <summary>
         /// List all recurring transactions with this currency.
@@ -304,7 +304,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>ApiResponse of RecurrenceArray</returns>
-        ApiResponse<RecurrenceArray> ListRecurrenceByCurrencyWithHttpInfo (string code, int? page = default(int?));
+        ApiResponse<RecurrenceArray> ListRecurrenceByCurrencyWithHttpInfo(string code, int? page = default(int?));
         /// <summary>
         /// List all rules with this currency.
         /// </summary>
@@ -315,7 +315,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination per 50. (optional)</param>
         /// <returns>RuleArray</returns>
-        RuleArray ListRuleByCurrency (string code, int? page = default(int?));
+        RuleArray ListRuleByCurrency(string code, int? page = default(int?));
 
         /// <summary>
         /// List all rules with this currency.
@@ -327,7 +327,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination per 50. (optional)</param>
         /// <returns>ApiResponse of RuleArray</returns>
-        ApiResponse<RuleArray> ListRuleByCurrencyWithHttpInfo (string code, int? page = default(int?));
+        ApiResponse<RuleArray> ListRuleByCurrencyWithHttpInfo(string code, int? page = default(int?));
         /// <summary>
         /// List all transactions with this currency.
         /// </summary>
@@ -341,7 +341,7 @@ namespace FireflyIII.Api
         /// <param name="endDate">A date formatted YYYY-MM-DD, to limit the list of transactions.  (optional)</param>
         /// <param name="type">Optional filter on the transaction type(s) returned (optional)</param>
         /// <returns>TransactionArray</returns>
-        TransactionArray ListTransactionByCurrency (string code, int? page = default(int?), DateTime? startDate = default(DateTime?), DateTime? endDate = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter));
+        TransactionArray ListTransactionByCurrency(string code, int? page = default(int?), DateTime? startDate = default(DateTime?), DateTime? endDate = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter));
 
         /// <summary>
         /// List all transactions with this currency.
@@ -356,7 +356,7 @@ namespace FireflyIII.Api
         /// <param name="endDate">A date formatted YYYY-MM-DD, to limit the list of transactions.  (optional)</param>
         /// <param name="type">Optional filter on the transaction type(s) returned (optional)</param>
         /// <returns>ApiResponse of TransactionArray</returns>
-        ApiResponse<TransactionArray> ListTransactionByCurrencyWithHttpInfo (string code, int? page = default(int?), DateTime? startDate = default(DateTime?), DateTime? endDate = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter));
+        ApiResponse<TransactionArray> ListTransactionByCurrencyWithHttpInfo(string code, int? page = default(int?), DateTime? startDate = default(DateTime?), DateTime? endDate = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter));
         /// <summary>
         /// Store a new currency
         /// </summary>
@@ -366,7 +366,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="currency">JSON array or key&#x3D;value pairs with the necessary currency information. See the model for the exact specifications.</param>
         /// <returns>CurrencySingle</returns>
-        CurrencySingle StoreCurrency (Currency currency);
+        CurrencySingle StoreCurrency(Currency currency);
 
         /// <summary>
         /// Store a new currency
@@ -377,7 +377,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="currency">JSON array or key&#x3D;value pairs with the necessary currency information. See the model for the exact specifications.</param>
         /// <returns>ApiResponse of CurrencySingle</returns>
-        ApiResponse<CurrencySingle> StoreCurrencyWithHttpInfo (Currency currency);
+        ApiResponse<CurrencySingle> StoreCurrencyWithHttpInfo(Currency currency);
         /// <summary>
         /// Update existing currency.
         /// </summary>
@@ -388,7 +388,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="currency">JSON array with updated currency information. See the model for the exact specifications.</param>
         /// <returns>CurrencySingle</returns>
-        CurrencySingle UpdateCurrency (string code, Currency currency);
+        CurrencySingle UpdateCurrency(string code, Currency currency);
 
         /// <summary>
         /// Update existing currency.
@@ -400,7 +400,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="currency">JSON array with updated currency information. See the model for the exact specifications.</param>
         /// <returns>ApiResponse of CurrencySingle</returns>
-        ApiResponse<CurrencySingle> UpdateCurrencyWithHttpInfo (string code, Currency currency);
+        ApiResponse<CurrencySingle> UpdateCurrencyWithHttpInfo(string code, Currency currency);
         #endregion Synchronous Operations
     }
 
@@ -419,7 +419,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>Task of CurrencySingle</returns>
-        System.Threading.Tasks.Task<CurrencySingle> DefaultCurrencyAsync (string code);
+        System.Threading.Tasks.Task<CurrencySingle> DefaultCurrencyAsync(string code);
 
         /// <summary>
         /// Make currency default currency.
@@ -430,7 +430,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>Task of ApiResponse (CurrencySingle)</returns>
-        System.Threading.Tasks.Task<ApiResponse<CurrencySingle>> DefaultCurrencyAsyncWithHttpInfo (string code);
+        System.Threading.Tasks.Task<ApiResponse<CurrencySingle>> DefaultCurrencyAsyncWithHttpInfo(string code);
         /// <summary>
         /// Delete a currency.
         /// </summary>
@@ -440,7 +440,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>Task of void</returns>
-        System.Threading.Tasks.Task DeleteCurrencyAsync (string code);
+        System.Threading.Tasks.Task DeleteCurrencyAsync(string code);
 
         /// <summary>
         /// Delete a currency.
@@ -451,7 +451,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>Task of ApiResponse</returns>
-        System.Threading.Tasks.Task<ApiResponse<Object>> DeleteCurrencyAsyncWithHttpInfo (string code);
+        System.Threading.Tasks.Task<ApiResponse<Object>> DeleteCurrencyAsyncWithHttpInfo(string code);
         /// <summary>
         /// Disable a currency.
         /// </summary>
@@ -461,7 +461,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>Task of CurrencySingle</returns>
-        System.Threading.Tasks.Task<CurrencySingle> DisableCurrencyAsync (int code);
+        System.Threading.Tasks.Task<CurrencySingle> DisableCurrencyAsync(int code);
 
         /// <summary>
         /// Disable a currency.
@@ -472,7 +472,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>Task of ApiResponse (CurrencySingle)</returns>
-        System.Threading.Tasks.Task<ApiResponse<CurrencySingle>> DisableCurrencyAsyncWithHttpInfo (int code);
+        System.Threading.Tasks.Task<ApiResponse<CurrencySingle>> DisableCurrencyAsyncWithHttpInfo(int code);
         /// <summary>
         /// Enable a single currency.
         /// </summary>
@@ -482,7 +482,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>Task of CurrencySingle</returns>
-        System.Threading.Tasks.Task<CurrencySingle> EnableCurrencyAsync (string code);
+        System.Threading.Tasks.Task<CurrencySingle> EnableCurrencyAsync(string code);
 
         /// <summary>
         /// Enable a single currency.
@@ -493,7 +493,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>Task of ApiResponse (CurrencySingle)</returns>
-        System.Threading.Tasks.Task<ApiResponse<CurrencySingle>> EnableCurrencyAsyncWithHttpInfo (string code);
+        System.Threading.Tasks.Task<ApiResponse<CurrencySingle>> EnableCurrencyAsyncWithHttpInfo(string code);
         /// <summary>
         /// Get a single currency.
         /// </summary>
@@ -503,7 +503,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>Task of CurrencySingle</returns>
-        System.Threading.Tasks.Task<CurrencySingle> GetCurrencyAsync (string code);
+        System.Threading.Tasks.Task<CurrencySingle> GetCurrencyAsync(string code);
 
         /// <summary>
         /// Get a single currency.
@@ -514,7 +514,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>Task of ApiResponse (CurrencySingle)</returns>
-        System.Threading.Tasks.Task<ApiResponse<CurrencySingle>> GetCurrencyAsyncWithHttpInfo (string code);
+        System.Threading.Tasks.Task<ApiResponse<CurrencySingle>> GetCurrencyAsyncWithHttpInfo(string code);
         /// <summary>
         /// List all accounts with this currency.
         /// </summary>
@@ -527,7 +527,7 @@ namespace FireflyIII.Api
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <param name="type">Optional filter on the account type(s) returned (optional)</param>
         /// <returns>Task of AccountArray</returns>
-        System.Threading.Tasks.Task<AccountArray> ListAccountByCurrencyAsync (string code, int? page = default(int?), string date = default(string), AccountTypeFilter type = default(AccountTypeFilter));
+        System.Threading.Tasks.Task<AccountArray> ListAccountByCurrencyAsync(string code, int? page = default(int?), string date = default(string), AccountTypeFilter type = default(AccountTypeFilter));
 
         /// <summary>
         /// List all accounts with this currency.
@@ -541,7 +541,7 @@ namespace FireflyIII.Api
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <param name="type">Optional filter on the account type(s) returned (optional)</param>
         /// <returns>Task of ApiResponse (AccountArray)</returns>
-        System.Threading.Tasks.Task<ApiResponse<AccountArray>> ListAccountByCurrencyAsyncWithHttpInfo (string code, int? page = default(int?), string date = default(string), AccountTypeFilter type = default(AccountTypeFilter));
+        System.Threading.Tasks.Task<ApiResponse<AccountArray>> ListAccountByCurrencyAsyncWithHttpInfo(string code, int? page = default(int?), string date = default(string), AccountTypeFilter type = default(AccountTypeFilter));
         /// <summary>
         /// List all available budgets with this currency.
         /// </summary>
@@ -552,7 +552,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50 (optional)</param>
         /// <returns>Task of AvailableBudgetArray</returns>
-        System.Threading.Tasks.Task<AvailableBudgetArray> ListAvailableBudgetByCurrencyAsync (string code, int? page = default(int?));
+        System.Threading.Tasks.Task<AvailableBudgetArray> ListAvailableBudgetByCurrencyAsync(string code, int? page = default(int?));
 
         /// <summary>
         /// List all available budgets with this currency.
@@ -564,7 +564,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50 (optional)</param>
         /// <returns>Task of ApiResponse (AvailableBudgetArray)</returns>
-        System.Threading.Tasks.Task<ApiResponse<AvailableBudgetArray>> ListAvailableBudgetByCurrencyAsyncWithHttpInfo (string code, int? page = default(int?));
+        System.Threading.Tasks.Task<ApiResponse<AvailableBudgetArray>> ListAvailableBudgetByCurrencyAsyncWithHttpInfo(string code, int? page = default(int?));
         /// <summary>
         /// List all bills with this currency.
         /// </summary>
@@ -575,7 +575,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>Task of BillArray</returns>
-        System.Threading.Tasks.Task<BillArray> ListBillByCurrencyAsync (string code, int? page = default(int?));
+        System.Threading.Tasks.Task<BillArray> ListBillByCurrencyAsync(string code, int? page = default(int?));
 
         /// <summary>
         /// List all bills with this currency.
@@ -587,7 +587,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>Task of ApiResponse (BillArray)</returns>
-        System.Threading.Tasks.Task<ApiResponse<BillArray>> ListBillByCurrencyAsyncWithHttpInfo (string code, int? page = default(int?));
+        System.Threading.Tasks.Task<ApiResponse<BillArray>> ListBillByCurrencyAsyncWithHttpInfo(string code, int? page = default(int?));
         /// <summary>
         /// List all budget limits with this currency
         /// </summary>
@@ -600,7 +600,7 @@ namespace FireflyIII.Api
         /// <param name="start">Start date for the budget limit list. (optional)</param>
         /// <param name="end">End date for the budget limit list. (optional)</param>
         /// <returns>Task of BudgetLimitArray</returns>
-        System.Threading.Tasks.Task<BudgetLimitArray> ListBudgetLimitByCurrencyAsync (string code, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?));
+        System.Threading.Tasks.Task<BudgetLimitArray> ListBudgetLimitByCurrencyAsync(string code, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?));
 
         /// <summary>
         /// List all budget limits with this currency
@@ -614,7 +614,7 @@ namespace FireflyIII.Api
         /// <param name="start">Start date for the budget limit list. (optional)</param>
         /// <param name="end">End date for the budget limit list. (optional)</param>
         /// <returns>Task of ApiResponse (BudgetLimitArray)</returns>
-        System.Threading.Tasks.Task<ApiResponse<BudgetLimitArray>> ListBudgetLimitByCurrencyAsyncWithHttpInfo (string code, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?));
+        System.Threading.Tasks.Task<ApiResponse<BudgetLimitArray>> ListBudgetLimitByCurrencyAsyncWithHttpInfo(string code, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?));
         /// <summary>
         /// List all currencies.
         /// </summary>
@@ -624,7 +624,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>Task of CurrencyArray</returns>
-        System.Threading.Tasks.Task<CurrencyArray> ListCurrencyAsync (int? page = default(int?));
+        System.Threading.Tasks.Task<CurrencyArray> ListCurrencyAsync(int? page = default(int?));
 
         /// <summary>
         /// List all currencies.
@@ -635,7 +635,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>Task of ApiResponse (CurrencyArray)</returns>
-        System.Threading.Tasks.Task<ApiResponse<CurrencyArray>> ListCurrencyAsyncWithHttpInfo (int? page = default(int?));
+        System.Threading.Tasks.Task<ApiResponse<CurrencyArray>> ListCurrencyAsyncWithHttpInfo(int? page = default(int?));
         /// <summary>
         /// List all known exchange rates with (from or to) this currency.
         /// </summary>
@@ -649,7 +649,7 @@ namespace FireflyIII.Api
         /// <param name="start">Use this instead of the date parameter to search for a range of currency exchange values.  (optional)</param>
         /// <param name="end">Use this instead of the date parameter to search for a range of currency exchange values.  (optional)</param>
         /// <returns>Task of ExchangeRateArray</returns>
-        System.Threading.Tasks.Task<ExchangeRateArray> ListExchangeRateByCurrencyAsync (string code, int? page = default(int?), DateTime? date = default(DateTime?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?));
+        System.Threading.Tasks.Task<ExchangeRateArray> ListExchangeRateByCurrencyAsync(string code, int? page = default(int?), DateTime? date = default(DateTime?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?));
 
         /// <summary>
         /// List all known exchange rates with (from or to) this currency.
@@ -664,7 +664,7 @@ namespace FireflyIII.Api
         /// <param name="start">Use this instead of the date parameter to search for a range of currency exchange values.  (optional)</param>
         /// <param name="end">Use this instead of the date parameter to search for a range of currency exchange values.  (optional)</param>
         /// <returns>Task of ApiResponse (ExchangeRateArray)</returns>
-        System.Threading.Tasks.Task<ApiResponse<ExchangeRateArray>> ListExchangeRateByCurrencyAsyncWithHttpInfo (string code, int? page = default(int?), DateTime? date = default(DateTime?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?));
+        System.Threading.Tasks.Task<ApiResponse<ExchangeRateArray>> ListExchangeRateByCurrencyAsyncWithHttpInfo(string code, int? page = default(int?), DateTime? date = default(DateTime?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?));
         /// <summary>
         /// List all recurring transactions with this currency.
         /// </summary>
@@ -675,7 +675,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>Task of RecurrenceArray</returns>
-        System.Threading.Tasks.Task<RecurrenceArray> ListRecurrenceByCurrencyAsync (string code, int? page = default(int?));
+        System.Threading.Tasks.Task<RecurrenceArray> ListRecurrenceByCurrencyAsync(string code, int? page = default(int?));
 
         /// <summary>
         /// List all recurring transactions with this currency.
@@ -687,7 +687,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>Task of ApiResponse (RecurrenceArray)</returns>
-        System.Threading.Tasks.Task<ApiResponse<RecurrenceArray>> ListRecurrenceByCurrencyAsyncWithHttpInfo (string code, int? page = default(int?));
+        System.Threading.Tasks.Task<ApiResponse<RecurrenceArray>> ListRecurrenceByCurrencyAsyncWithHttpInfo(string code, int? page = default(int?));
         /// <summary>
         /// List all rules with this currency.
         /// </summary>
@@ -698,7 +698,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination per 50. (optional)</param>
         /// <returns>Task of RuleArray</returns>
-        System.Threading.Tasks.Task<RuleArray> ListRuleByCurrencyAsync (string code, int? page = default(int?));
+        System.Threading.Tasks.Task<RuleArray> ListRuleByCurrencyAsync(string code, int? page = default(int?));
 
         /// <summary>
         /// List all rules with this currency.
@@ -710,7 +710,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination per 50. (optional)</param>
         /// <returns>Task of ApiResponse (RuleArray)</returns>
-        System.Threading.Tasks.Task<ApiResponse<RuleArray>> ListRuleByCurrencyAsyncWithHttpInfo (string code, int? page = default(int?));
+        System.Threading.Tasks.Task<ApiResponse<RuleArray>> ListRuleByCurrencyAsyncWithHttpInfo(string code, int? page = default(int?));
         /// <summary>
         /// List all transactions with this currency.
         /// </summary>
@@ -724,7 +724,7 @@ namespace FireflyIII.Api
         /// <param name="endDate">A date formatted YYYY-MM-DD, to limit the list of transactions.  (optional)</param>
         /// <param name="type">Optional filter on the transaction type(s) returned (optional)</param>
         /// <returns>Task of TransactionArray</returns>
-        System.Threading.Tasks.Task<TransactionArray> ListTransactionByCurrencyAsync (string code, int? page = default(int?), DateTime? startDate = default(DateTime?), DateTime? endDate = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter));
+        System.Threading.Tasks.Task<TransactionArray> ListTransactionByCurrencyAsync(string code, int? page = default(int?), DateTime? startDate = default(DateTime?), DateTime? endDate = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter));
 
         /// <summary>
         /// List all transactions with this currency.
@@ -739,7 +739,7 @@ namespace FireflyIII.Api
         /// <param name="endDate">A date formatted YYYY-MM-DD, to limit the list of transactions.  (optional)</param>
         /// <param name="type">Optional filter on the transaction type(s) returned (optional)</param>
         /// <returns>Task of ApiResponse (TransactionArray)</returns>
-        System.Threading.Tasks.Task<ApiResponse<TransactionArray>> ListTransactionByCurrencyAsyncWithHttpInfo (string code, int? page = default(int?), DateTime? startDate = default(DateTime?), DateTime? endDate = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter));
+        System.Threading.Tasks.Task<ApiResponse<TransactionArray>> ListTransactionByCurrencyAsyncWithHttpInfo(string code, int? page = default(int?), DateTime? startDate = default(DateTime?), DateTime? endDate = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter));
         /// <summary>
         /// Store a new currency
         /// </summary>
@@ -749,7 +749,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="currency">JSON array or key&#x3D;value pairs with the necessary currency information. See the model for the exact specifications.</param>
         /// <returns>Task of CurrencySingle</returns>
-        System.Threading.Tasks.Task<CurrencySingle> StoreCurrencyAsync (Currency currency);
+        System.Threading.Tasks.Task<CurrencySingle> StoreCurrencyAsync(Currency currency);
 
         /// <summary>
         /// Store a new currency
@@ -760,7 +760,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="currency">JSON array or key&#x3D;value pairs with the necessary currency information. See the model for the exact specifications.</param>
         /// <returns>Task of ApiResponse (CurrencySingle)</returns>
-        System.Threading.Tasks.Task<ApiResponse<CurrencySingle>> StoreCurrencyAsyncWithHttpInfo (Currency currency);
+        System.Threading.Tasks.Task<ApiResponse<CurrencySingle>> StoreCurrencyAsyncWithHttpInfo(Currency currency);
         /// <summary>
         /// Update existing currency.
         /// </summary>
@@ -771,7 +771,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="currency">JSON array with updated currency information. See the model for the exact specifications.</param>
         /// <returns>Task of CurrencySingle</returns>
-        System.Threading.Tasks.Task<CurrencySingle> UpdateCurrencyAsync (string code, Currency currency);
+        System.Threading.Tasks.Task<CurrencySingle> UpdateCurrencyAsync(string code, Currency currency);
 
         /// <summary>
         /// Update existing currency.
@@ -783,7 +783,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="currency">JSON array with updated currency information. See the model for the exact specifications.</param>
         /// <returns>Task of ApiResponse (CurrencySingle)</returns>
-        System.Threading.Tasks.Task<ApiResponse<CurrencySingle>> UpdateCurrencyAsyncWithHttpInfo (string code, Currency currency);
+        System.Threading.Tasks.Task<ApiResponse<CurrencySingle>> UpdateCurrencyAsyncWithHttpInfo(string code, Currency currency);
         #endregion Asynchronous Operations
     }
 
@@ -806,7 +806,7 @@ namespace FireflyIII.Api
         /// Initializes a new instance of the <see cref="CurrenciesApi"/> class.
         /// </summary>
         /// <returns></returns>
-        public CurrenciesApi() : this((string) null)
+        public CurrenciesApi() : this((string)null)
         {
         }
 
@@ -851,11 +851,11 @@ namespace FireflyIII.Api
         /// <param name="client">The client interface for synchronous API access.</param>
         /// <param name="asyncClient">The client interface for asynchronous API access.</param>
         /// <param name="configuration">The configuration object.</param>
-        public CurrenciesApi(FireflyIII.Client.ISynchronousClient client,FireflyIII.Client.IAsynchronousClient asyncClient, FireflyIII.Client.IReadableConfiguration configuration)
+        public CurrenciesApi(FireflyIII.Client.ISynchronousClient client, FireflyIII.Client.IAsynchronousClient asyncClient, FireflyIII.Client.IReadableConfiguration configuration)
         {
-            if(client == null) throw new ArgumentNullException("client");
-            if(asyncClient == null) throw new ArgumentNullException("asyncClient");
-            if(configuration == null) throw new ArgumentNullException("configuration");
+            if (client == null) throw new ArgumentNullException("client");
+            if (asyncClient == null) throw new ArgumentNullException("asyncClient");
+            if (configuration == null) throw new ArgumentNullException("configuration");
 
             this.Client = client;
             this.AsynchronousClient = asyncClient;
@@ -886,7 +886,7 @@ namespace FireflyIII.Api
         /// Gets or sets the configuration object
         /// </summary>
         /// <value>An instance of the Configuration</value>
-        public FireflyIII.Client.IReadableConfiguration Configuration {get; set;}
+        public FireflyIII.Client.IReadableConfiguration Configuration { get; set; }
 
         /// <summary>
         /// Provides a factory method hook for the creation of exceptions.
@@ -910,10 +910,10 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>CurrencySingle</returns>
-        public CurrencySingle DefaultCurrency (string code)
+        public CurrencySingle DefaultCurrency(string code)
         {
-             FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = DefaultCurrencyWithHttpInfo(code);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = DefaultCurrencyWithHttpInfo(code);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -922,7 +922,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>ApiResponse of CurrencySingle</returns>
-        public FireflyIII.Client.ApiResponse< CurrencySingle > DefaultCurrencyWithHttpInfo (string code)
+        public FireflyIII.Client.ApiResponse<CurrencySingle> DefaultCurrencyWithHttpInfo(string code)
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -955,7 +955,7 @@ namespace FireflyIII.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post< CurrencySingle >("/api/v1/currencies/{code}/default", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<CurrencySingle>("/api/v1/currencies/{code}/default", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -972,10 +972,10 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>Task of CurrencySingle</returns>
-        public async System.Threading.Tasks.Task<CurrencySingle> DefaultCurrencyAsync (string code)
+        public async System.Threading.Tasks.Task<CurrencySingle> DefaultCurrencyAsync(string code)
         {
-             FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = await DefaultCurrencyAsyncWithHttpInfo(code);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = await DefaultCurrencyAsyncWithHttpInfo(code);
+            return localVarResponse.Data;
 
         }
 
@@ -985,7 +985,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>Task of ApiResponse (CurrencySingle)</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<CurrencySingle>> DefaultCurrencyAsyncWithHttpInfo (string code)
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<CurrencySingle>> DefaultCurrencyAsyncWithHttpInfo(string code)
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -1001,13 +1001,13 @@ namespace FireflyIII.Api
             String[] _accepts = new String[] {
                 "application/json"
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
-            
+
             if (code != null)
                 localVarRequestOptions.PathParameters.Add("code", FireflyIII.Client.ClientUtils.ParameterToString(code)); // path parameter
 
@@ -1037,9 +1037,9 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns></returns>
-        public void DeleteCurrency (string code)
+        public void DeleteCurrency(string code)
         {
-             DeleteCurrencyWithHttpInfo(code);
+            DeleteCurrencyWithHttpInfo(code);
         }
 
         /// <summary>
@@ -1048,7 +1048,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>ApiResponse of Object(void)</returns>
-        public FireflyIII.Client.ApiResponse<Object> DeleteCurrencyWithHttpInfo (string code)
+        public FireflyIII.Client.ApiResponse<Object> DeleteCurrencyWithHttpInfo(string code)
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -1097,9 +1097,9 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteCurrencyAsync (string code)
+        public async System.Threading.Tasks.Task DeleteCurrencyAsync(string code)
         {
-             await DeleteCurrencyAsyncWithHttpInfo(code);
+            await DeleteCurrencyAsyncWithHttpInfo(code);
 
         }
 
@@ -1109,7 +1109,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>Task of ApiResponse</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<Object>> DeleteCurrencyAsyncWithHttpInfo (string code)
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<Object>> DeleteCurrencyAsyncWithHttpInfo(string code)
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -1124,13 +1124,13 @@ namespace FireflyIII.Api
             // to determine the Accept header
             String[] _accepts = new String[] {
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
-            
+
             if (code != null)
                 localVarRequestOptions.PathParameters.Add("code", FireflyIII.Client.ClientUtils.ParameterToString(code)); // path parameter
 
@@ -1160,10 +1160,10 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>CurrencySingle</returns>
-        public CurrencySingle DisableCurrency (int code)
+        public CurrencySingle DisableCurrency(int code)
         {
-             FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = DisableCurrencyWithHttpInfo(code);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = DisableCurrencyWithHttpInfo(code);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -1172,10 +1172,10 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>ApiResponse of CurrencySingle</returns>
-        public FireflyIII.Client.ApiResponse< CurrencySingle > DisableCurrencyWithHttpInfo (int code)
+        public FireflyIII.Client.ApiResponse<CurrencySingle> DisableCurrencyWithHttpInfo(int code)
         {
             // verify the required parameter 'code' is set
-            if (code == null)
+            if (code == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'code' when calling CurrenciesApi->DisableCurrency");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -1194,8 +1194,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (code != null)
-                localVarRequestOptions.PathParameters.Add("code", FireflyIII.Client.ClientUtils.ParameterToString(code)); // path parameter
+            localVarRequestOptions.PathParameters.Add("code", FireflyIII.Client.ClientUtils.ParameterToString(code)); // path parameter
 
             // authentication (firefly_iii_auth) required
             // oauth required
@@ -1205,7 +1204,7 @@ namespace FireflyIII.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post< CurrencySingle >("/api/v1/currencies/{code}/disable", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<CurrencySingle>("/api/v1/currencies/{code}/disable", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1222,10 +1221,10 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>Task of CurrencySingle</returns>
-        public async System.Threading.Tasks.Task<CurrencySingle> DisableCurrencyAsync (int code)
+        public async System.Threading.Tasks.Task<CurrencySingle> DisableCurrencyAsync(int code)
         {
-             FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = await DisableCurrencyAsyncWithHttpInfo(code);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = await DisableCurrencyAsyncWithHttpInfo(code);
+            return localVarResponse.Data;
 
         }
 
@@ -1235,10 +1234,10 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>Task of ApiResponse (CurrencySingle)</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<CurrencySingle>> DisableCurrencyAsyncWithHttpInfo (int code)
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<CurrencySingle>> DisableCurrencyAsyncWithHttpInfo(int code)
         {
             // verify the required parameter 'code' is set
-            if (code == null)
+            if (code == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'code' when calling CurrenciesApi->DisableCurrency");
 
 
@@ -1251,15 +1250,14 @@ namespace FireflyIII.Api
             String[] _accepts = new String[] {
                 "application/json"
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
-            
-            if (code != null)
-                localVarRequestOptions.PathParameters.Add("code", FireflyIII.Client.ClientUtils.ParameterToString(code)); // path parameter
+
+            localVarRequestOptions.PathParameters.Add("code", FireflyIII.Client.ClientUtils.ParameterToString(code)); // path parameter
 
             // authentication (firefly_iii_auth) required
             // oauth required
@@ -1287,10 +1285,10 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>CurrencySingle</returns>
-        public CurrencySingle EnableCurrency (string code)
+        public CurrencySingle EnableCurrency(string code)
         {
-             FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = EnableCurrencyWithHttpInfo(code);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = EnableCurrencyWithHttpInfo(code);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -1299,7 +1297,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>ApiResponse of CurrencySingle</returns>
-        public FireflyIII.Client.ApiResponse< CurrencySingle > EnableCurrencyWithHttpInfo (string code)
+        public FireflyIII.Client.ApiResponse<CurrencySingle> EnableCurrencyWithHttpInfo(string code)
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -1332,7 +1330,7 @@ namespace FireflyIII.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post< CurrencySingle >("/api/v1/currencies/{code}/enable", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<CurrencySingle>("/api/v1/currencies/{code}/enable", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1349,10 +1347,10 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>Task of CurrencySingle</returns>
-        public async System.Threading.Tasks.Task<CurrencySingle> EnableCurrencyAsync (string code)
+        public async System.Threading.Tasks.Task<CurrencySingle> EnableCurrencyAsync(string code)
         {
-             FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = await EnableCurrencyAsyncWithHttpInfo(code);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = await EnableCurrencyAsyncWithHttpInfo(code);
+            return localVarResponse.Data;
 
         }
 
@@ -1362,7 +1360,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>Task of ApiResponse (CurrencySingle)</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<CurrencySingle>> EnableCurrencyAsyncWithHttpInfo (string code)
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<CurrencySingle>> EnableCurrencyAsyncWithHttpInfo(string code)
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -1378,13 +1376,13 @@ namespace FireflyIII.Api
             String[] _accepts = new String[] {
                 "application/json"
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
-            
+
             if (code != null)
                 localVarRequestOptions.PathParameters.Add("code", FireflyIII.Client.ClientUtils.ParameterToString(code)); // path parameter
 
@@ -1414,10 +1412,10 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>CurrencySingle</returns>
-        public CurrencySingle GetCurrency (string code)
+        public CurrencySingle GetCurrency(string code)
         {
-             FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = GetCurrencyWithHttpInfo(code);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = GetCurrencyWithHttpInfo(code);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -1426,7 +1424,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>ApiResponse of CurrencySingle</returns>
-        public FireflyIII.Client.ApiResponse< CurrencySingle > GetCurrencyWithHttpInfo (string code)
+        public FireflyIII.Client.ApiResponse<CurrencySingle> GetCurrencyWithHttpInfo(string code)
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -1459,7 +1457,7 @@ namespace FireflyIII.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get< CurrencySingle >("/api/v1/currencies/{code}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<CurrencySingle>("/api/v1/currencies/{code}", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1476,10 +1474,10 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>Task of CurrencySingle</returns>
-        public async System.Threading.Tasks.Task<CurrencySingle> GetCurrencyAsync (string code)
+        public async System.Threading.Tasks.Task<CurrencySingle> GetCurrencyAsync(string code)
         {
-             FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = await GetCurrencyAsyncWithHttpInfo(code);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = await GetCurrencyAsyncWithHttpInfo(code);
+            return localVarResponse.Data;
 
         }
 
@@ -1489,7 +1487,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="code">The currency code.</param>
         /// <returns>Task of ApiResponse (CurrencySingle)</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<CurrencySingle>> GetCurrencyAsyncWithHttpInfo (string code)
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<CurrencySingle>> GetCurrencyAsyncWithHttpInfo(string code)
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -1505,13 +1503,13 @@ namespace FireflyIII.Api
             String[] _accepts = new String[] {
                 "application/json"
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
-            
+
             if (code != null)
                 localVarRequestOptions.PathParameters.Add("code", FireflyIII.Client.ClientUtils.ParameterToString(code)); // path parameter
 
@@ -1544,10 +1542,10 @@ namespace FireflyIII.Api
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <param name="type">Optional filter on the account type(s) returned (optional)</param>
         /// <returns>AccountArray</returns>
-        public AccountArray ListAccountByCurrency (string code, int? page = default(int?), string date = default(string), AccountTypeFilter type = default(AccountTypeFilter))
+        public AccountArray ListAccountByCurrency(string code, int? page = default(int?), string date = default(string), AccountTypeFilter type = default(AccountTypeFilter))
         {
-             FireflyIII.Client.ApiResponse<AccountArray> localVarResponse = ListAccountByCurrencyWithHttpInfo(code, page, date, type);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<AccountArray> localVarResponse = ListAccountByCurrencyWithHttpInfo(code, page, date, type);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -1559,7 +1557,7 @@ namespace FireflyIII.Api
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <param name="type">Optional filter on the account type(s) returned (optional)</param>
         /// <returns>ApiResponse of AccountArray</returns>
-        public FireflyIII.Client.ApiResponse< AccountArray > ListAccountByCurrencyWithHttpInfo (string code, int? page = default(int?), string date = default(string), AccountTypeFilter type = default(AccountTypeFilter))
+        public FireflyIII.Client.ApiResponse<AccountArray> ListAccountByCurrencyWithHttpInfo(string code, int? page = default(int?), string date = default(string), AccountTypeFilter type = default(AccountTypeFilter))
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -1603,7 +1601,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -1622,7 +1620,7 @@ namespace FireflyIII.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get< AccountArray >("/api/v1/currencies/{code}/accounts", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<AccountArray>("/api/v1/currencies/{code}/accounts", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1642,10 +1640,10 @@ namespace FireflyIII.Api
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <param name="type">Optional filter on the account type(s) returned (optional)</param>
         /// <returns>Task of AccountArray</returns>
-        public async System.Threading.Tasks.Task<AccountArray> ListAccountByCurrencyAsync (string code, int? page = default(int?), string date = default(string), AccountTypeFilter type = default(AccountTypeFilter))
+        public async System.Threading.Tasks.Task<AccountArray> ListAccountByCurrencyAsync(string code, int? page = default(int?), string date = default(string), AccountTypeFilter type = default(AccountTypeFilter))
         {
-             FireflyIII.Client.ApiResponse<AccountArray> localVarResponse = await ListAccountByCurrencyAsyncWithHttpInfo(code, page, date, type);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<AccountArray> localVarResponse = await ListAccountByCurrencyAsyncWithHttpInfo(code, page, date, type);
+            return localVarResponse.Data;
 
         }
 
@@ -1658,7 +1656,7 @@ namespace FireflyIII.Api
         /// <param name="date">A date formatted YYYY-MM-DD. When added to the request, Firefly III will show the account&#39;s balance on that day.  (optional)</param>
         /// <param name="type">Optional filter on the account type(s) returned (optional)</param>
         /// <returns>Task of ApiResponse (AccountArray)</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<AccountArray>> ListAccountByCurrencyAsyncWithHttpInfo (string code, int? page = default(int?), string date = default(string), AccountTypeFilter type = default(AccountTypeFilter))
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<AccountArray>> ListAccountByCurrencyAsyncWithHttpInfo(string code, int? page = default(int?), string date = default(string), AccountTypeFilter type = default(AccountTypeFilter))
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -1674,13 +1672,13 @@ namespace FireflyIII.Api
             String[] _accepts = new String[] {
                 "application/json"
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
-            
+
             if (code != null)
                 localVarRequestOptions.PathParameters.Add("code", FireflyIII.Client.ClientUtils.ParameterToString(code)); // path parameter
             if (page != null)
@@ -1703,7 +1701,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -1741,10 +1739,10 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50 (optional)</param>
         /// <returns>AvailableBudgetArray</returns>
-        public AvailableBudgetArray ListAvailableBudgetByCurrency (string code, int? page = default(int?))
+        public AvailableBudgetArray ListAvailableBudgetByCurrency(string code, int? page = default(int?))
         {
-             FireflyIII.Client.ApiResponse<AvailableBudgetArray> localVarResponse = ListAvailableBudgetByCurrencyWithHttpInfo(code, page);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<AvailableBudgetArray> localVarResponse = ListAvailableBudgetByCurrencyWithHttpInfo(code, page);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -1754,7 +1752,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50 (optional)</param>
         /// <returns>ApiResponse of AvailableBudgetArray</returns>
-        public FireflyIII.Client.ApiResponse< AvailableBudgetArray > ListAvailableBudgetByCurrencyWithHttpInfo (string code, int? page = default(int?))
+        public FireflyIII.Client.ApiResponse<AvailableBudgetArray> ListAvailableBudgetByCurrencyWithHttpInfo(string code, int? page = default(int?))
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -1797,7 +1795,7 @@ namespace FireflyIII.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get< AvailableBudgetArray >("/api/v1/currencies/{code}/available_budgets", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<AvailableBudgetArray>("/api/v1/currencies/{code}/available_budgets", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1815,10 +1813,10 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50 (optional)</param>
         /// <returns>Task of AvailableBudgetArray</returns>
-        public async System.Threading.Tasks.Task<AvailableBudgetArray> ListAvailableBudgetByCurrencyAsync (string code, int? page = default(int?))
+        public async System.Threading.Tasks.Task<AvailableBudgetArray> ListAvailableBudgetByCurrencyAsync(string code, int? page = default(int?))
         {
-             FireflyIII.Client.ApiResponse<AvailableBudgetArray> localVarResponse = await ListAvailableBudgetByCurrencyAsyncWithHttpInfo(code, page);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<AvailableBudgetArray> localVarResponse = await ListAvailableBudgetByCurrencyAsyncWithHttpInfo(code, page);
+            return localVarResponse.Data;
 
         }
 
@@ -1829,7 +1827,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50 (optional)</param>
         /// <returns>Task of ApiResponse (AvailableBudgetArray)</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<AvailableBudgetArray>> ListAvailableBudgetByCurrencyAsyncWithHttpInfo (string code, int? page = default(int?))
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<AvailableBudgetArray>> ListAvailableBudgetByCurrencyAsyncWithHttpInfo(string code, int? page = default(int?))
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -1845,13 +1843,13 @@ namespace FireflyIII.Api
             String[] _accepts = new String[] {
                 "application/json"
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
-            
+
             if (code != null)
                 localVarRequestOptions.PathParameters.Add("code", FireflyIII.Client.ClientUtils.ParameterToString(code)); // path parameter
             if (page != null)
@@ -1892,10 +1890,10 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>BillArray</returns>
-        public BillArray ListBillByCurrency (string code, int? page = default(int?))
+        public BillArray ListBillByCurrency(string code, int? page = default(int?))
         {
-             FireflyIII.Client.ApiResponse<BillArray> localVarResponse = ListBillByCurrencyWithHttpInfo(code, page);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<BillArray> localVarResponse = ListBillByCurrencyWithHttpInfo(code, page);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -1905,7 +1903,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>ApiResponse of BillArray</returns>
-        public FireflyIII.Client.ApiResponse< BillArray > ListBillByCurrencyWithHttpInfo (string code, int? page = default(int?))
+        public FireflyIII.Client.ApiResponse<BillArray> ListBillByCurrencyWithHttpInfo(string code, int? page = default(int?))
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -1948,7 +1946,7 @@ namespace FireflyIII.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get< BillArray >("/api/v1/currencies/{code}/bills", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<BillArray>("/api/v1/currencies/{code}/bills", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -1966,10 +1964,10 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>Task of BillArray</returns>
-        public async System.Threading.Tasks.Task<BillArray> ListBillByCurrencyAsync (string code, int? page = default(int?))
+        public async System.Threading.Tasks.Task<BillArray> ListBillByCurrencyAsync(string code, int? page = default(int?))
         {
-             FireflyIII.Client.ApiResponse<BillArray> localVarResponse = await ListBillByCurrencyAsyncWithHttpInfo(code, page);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<BillArray> localVarResponse = await ListBillByCurrencyAsyncWithHttpInfo(code, page);
+            return localVarResponse.Data;
 
         }
 
@@ -1980,7 +1978,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>Task of ApiResponse (BillArray)</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<BillArray>> ListBillByCurrencyAsyncWithHttpInfo (string code, int? page = default(int?))
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<BillArray>> ListBillByCurrencyAsyncWithHttpInfo(string code, int? page = default(int?))
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -1996,13 +1994,13 @@ namespace FireflyIII.Api
             String[] _accepts = new String[] {
                 "application/json"
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
-            
+
             if (code != null)
                 localVarRequestOptions.PathParameters.Add("code", FireflyIII.Client.ClientUtils.ParameterToString(code)); // path parameter
             if (page != null)
@@ -2045,10 +2043,10 @@ namespace FireflyIII.Api
         /// <param name="start">Start date for the budget limit list. (optional)</param>
         /// <param name="end">End date for the budget limit list. (optional)</param>
         /// <returns>BudgetLimitArray</returns>
-        public BudgetLimitArray ListBudgetLimitByCurrency (string code, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?))
+        public BudgetLimitArray ListBudgetLimitByCurrency(string code, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?))
         {
-             FireflyIII.Client.ApiResponse<BudgetLimitArray> localVarResponse = ListBudgetLimitByCurrencyWithHttpInfo(code, page, start, end);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<BudgetLimitArray> localVarResponse = ListBudgetLimitByCurrencyWithHttpInfo(code, page, start, end);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -2060,7 +2058,7 @@ namespace FireflyIII.Api
         /// <param name="start">Start date for the budget limit list. (optional)</param>
         /// <param name="end">End date for the budget limit list. (optional)</param>
         /// <returns>ApiResponse of BudgetLimitArray</returns>
-        public FireflyIII.Client.ApiResponse< BudgetLimitArray > ListBudgetLimitByCurrencyWithHttpInfo (string code, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?))
+        public FireflyIII.Client.ApiResponse<BudgetLimitArray> ListBudgetLimitByCurrencyWithHttpInfo(string code, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?))
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -2123,7 +2121,7 @@ namespace FireflyIII.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get< BudgetLimitArray >("/api/v1/currencies/{code}/budget_limits", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<BudgetLimitArray>("/api/v1/currencies/{code}/budget_limits", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -2143,10 +2141,10 @@ namespace FireflyIII.Api
         /// <param name="start">Start date for the budget limit list. (optional)</param>
         /// <param name="end">End date for the budget limit list. (optional)</param>
         /// <returns>Task of BudgetLimitArray</returns>
-        public async System.Threading.Tasks.Task<BudgetLimitArray> ListBudgetLimitByCurrencyAsync (string code, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?))
+        public async System.Threading.Tasks.Task<BudgetLimitArray> ListBudgetLimitByCurrencyAsync(string code, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?))
         {
-             FireflyIII.Client.ApiResponse<BudgetLimitArray> localVarResponse = await ListBudgetLimitByCurrencyAsyncWithHttpInfo(code, page, start, end);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<BudgetLimitArray> localVarResponse = await ListBudgetLimitByCurrencyAsyncWithHttpInfo(code, page, start, end);
+            return localVarResponse.Data;
 
         }
 
@@ -2159,7 +2157,7 @@ namespace FireflyIII.Api
         /// <param name="start">Start date for the budget limit list. (optional)</param>
         /// <param name="end">End date for the budget limit list. (optional)</param>
         /// <returns>Task of ApiResponse (BudgetLimitArray)</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<BudgetLimitArray>> ListBudgetLimitByCurrencyAsyncWithHttpInfo (string code, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?))
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<BudgetLimitArray>> ListBudgetLimitByCurrencyAsyncWithHttpInfo(string code, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?))
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -2175,13 +2173,13 @@ namespace FireflyIII.Api
             String[] _accepts = new String[] {
                 "application/json"
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
-            
+
             if (code != null)
                 localVarRequestOptions.PathParameters.Add("code", FireflyIII.Client.ClientUtils.ParameterToString(code)); // path parameter
             if (page != null)
@@ -2241,10 +2239,10 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>CurrencyArray</returns>
-        public CurrencyArray ListCurrency (int? page = default(int?))
+        public CurrencyArray ListCurrency(int? page = default(int?))
         {
-             FireflyIII.Client.ApiResponse<CurrencyArray> localVarResponse = ListCurrencyWithHttpInfo(page);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<CurrencyArray> localVarResponse = ListCurrencyWithHttpInfo(page);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -2253,7 +2251,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>ApiResponse of CurrencyArray</returns>
-        public FireflyIII.Client.ApiResponse< CurrencyArray > ListCurrencyWithHttpInfo (int? page = default(int?))
+        public FireflyIII.Client.ApiResponse<CurrencyArray> ListCurrencyWithHttpInfo(int? page = default(int?))
         {
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
 
@@ -2290,7 +2288,7 @@ namespace FireflyIII.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get< CurrencyArray >("/api/v1/currencies", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<CurrencyArray>("/api/v1/currencies", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -2307,10 +2305,10 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>Task of CurrencyArray</returns>
-        public async System.Threading.Tasks.Task<CurrencyArray> ListCurrencyAsync (int? page = default(int?))
+        public async System.Threading.Tasks.Task<CurrencyArray> ListCurrencyAsync(int? page = default(int?))
         {
-             FireflyIII.Client.ApiResponse<CurrencyArray> localVarResponse = await ListCurrencyAsyncWithHttpInfo(page);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<CurrencyArray> localVarResponse = await ListCurrencyAsyncWithHttpInfo(page);
+            return localVarResponse.Data;
 
         }
 
@@ -2320,7 +2318,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>Task of ApiResponse (CurrencyArray)</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<CurrencyArray>> ListCurrencyAsyncWithHttpInfo (int? page = default(int?))
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<CurrencyArray>> ListCurrencyAsyncWithHttpInfo(int? page = default(int?))
         {
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -2332,13 +2330,13 @@ namespace FireflyIII.Api
             String[] _accepts = new String[] {
                 "application/json"
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
-            
+
             if (page != null)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "page", page))
@@ -2380,10 +2378,10 @@ namespace FireflyIII.Api
         /// <param name="start">Use this instead of the date parameter to search for a range of currency exchange values.  (optional)</param>
         /// <param name="end">Use this instead of the date parameter to search for a range of currency exchange values.  (optional)</param>
         /// <returns>ExchangeRateArray</returns>
-        public ExchangeRateArray ListExchangeRateByCurrency (string code, int? page = default(int?), DateTime? date = default(DateTime?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?))
+        public ExchangeRateArray ListExchangeRateByCurrency(string code, int? page = default(int?), DateTime? date = default(DateTime?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?))
         {
-             FireflyIII.Client.ApiResponse<ExchangeRateArray> localVarResponse = ListExchangeRateByCurrencyWithHttpInfo(code, page, date, start, end);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<ExchangeRateArray> localVarResponse = ListExchangeRateByCurrencyWithHttpInfo(code, page, date, start, end);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -2396,7 +2394,7 @@ namespace FireflyIII.Api
         /// <param name="start">Use this instead of the date parameter to search for a range of currency exchange values.  (optional)</param>
         /// <param name="end">Use this instead of the date parameter to search for a range of currency exchange values.  (optional)</param>
         /// <returns>ApiResponse of ExchangeRateArray</returns>
-        public FireflyIII.Client.ApiResponse< ExchangeRateArray > ListExchangeRateByCurrencyWithHttpInfo (string code, int? page = default(int?), DateTime? date = default(DateTime?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?))
+        public FireflyIII.Client.ApiResponse<ExchangeRateArray> ListExchangeRateByCurrencyWithHttpInfo(string code, int? page = default(int?), DateTime? date = default(DateTime?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?))
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -2469,7 +2467,7 @@ namespace FireflyIII.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get< ExchangeRateArray >("/api/v1/currencies/{code}/cer", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<ExchangeRateArray>("/api/v1/currencies/{code}/cer", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -2490,10 +2488,10 @@ namespace FireflyIII.Api
         /// <param name="start">Use this instead of the date parameter to search for a range of currency exchange values.  (optional)</param>
         /// <param name="end">Use this instead of the date parameter to search for a range of currency exchange values.  (optional)</param>
         /// <returns>Task of ExchangeRateArray</returns>
-        public async System.Threading.Tasks.Task<ExchangeRateArray> ListExchangeRateByCurrencyAsync (string code, int? page = default(int?), DateTime? date = default(DateTime?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?))
+        public async System.Threading.Tasks.Task<ExchangeRateArray> ListExchangeRateByCurrencyAsync(string code, int? page = default(int?), DateTime? date = default(DateTime?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?))
         {
-             FireflyIII.Client.ApiResponse<ExchangeRateArray> localVarResponse = await ListExchangeRateByCurrencyAsyncWithHttpInfo(code, page, date, start, end);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<ExchangeRateArray> localVarResponse = await ListExchangeRateByCurrencyAsyncWithHttpInfo(code, page, date, start, end);
+            return localVarResponse.Data;
 
         }
 
@@ -2507,7 +2505,7 @@ namespace FireflyIII.Api
         /// <param name="start">Use this instead of the date parameter to search for a range of currency exchange values.  (optional)</param>
         /// <param name="end">Use this instead of the date parameter to search for a range of currency exchange values.  (optional)</param>
         /// <returns>Task of ApiResponse (ExchangeRateArray)</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<ExchangeRateArray>> ListExchangeRateByCurrencyAsyncWithHttpInfo (string code, int? page = default(int?), DateTime? date = default(DateTime?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?))
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<ExchangeRateArray>> ListExchangeRateByCurrencyAsyncWithHttpInfo(string code, int? page = default(int?), DateTime? date = default(DateTime?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?))
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -2523,13 +2521,13 @@ namespace FireflyIII.Api
             String[] _accepts = new String[] {
                 "application/json"
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
-            
+
             if (code != null)
                 localVarRequestOptions.PathParameters.Add("code", FireflyIII.Client.ClientUtils.ParameterToString(code)); // path parameter
             if (page != null)
@@ -2600,10 +2598,10 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>RecurrenceArray</returns>
-        public RecurrenceArray ListRecurrenceByCurrency (string code, int? page = default(int?))
+        public RecurrenceArray ListRecurrenceByCurrency(string code, int? page = default(int?))
         {
-             FireflyIII.Client.ApiResponse<RecurrenceArray> localVarResponse = ListRecurrenceByCurrencyWithHttpInfo(code, page);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<RecurrenceArray> localVarResponse = ListRecurrenceByCurrencyWithHttpInfo(code, page);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -2613,7 +2611,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>ApiResponse of RecurrenceArray</returns>
-        public FireflyIII.Client.ApiResponse< RecurrenceArray > ListRecurrenceByCurrencyWithHttpInfo (string code, int? page = default(int?))
+        public FireflyIII.Client.ApiResponse<RecurrenceArray> ListRecurrenceByCurrencyWithHttpInfo(string code, int? page = default(int?))
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -2656,7 +2654,7 @@ namespace FireflyIII.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get< RecurrenceArray >("/api/v1/currencies/{code}/recurrences", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<RecurrenceArray>("/api/v1/currencies/{code}/recurrences", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -2674,10 +2672,10 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>Task of RecurrenceArray</returns>
-        public async System.Threading.Tasks.Task<RecurrenceArray> ListRecurrenceByCurrencyAsync (string code, int? page = default(int?))
+        public async System.Threading.Tasks.Task<RecurrenceArray> ListRecurrenceByCurrencyAsync(string code, int? page = default(int?))
         {
-             FireflyIII.Client.ApiResponse<RecurrenceArray> localVarResponse = await ListRecurrenceByCurrencyAsyncWithHttpInfo(code, page);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<RecurrenceArray> localVarResponse = await ListRecurrenceByCurrencyAsyncWithHttpInfo(code, page);
+            return localVarResponse.Data;
 
         }
 
@@ -2688,7 +2686,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination is 50. (optional)</param>
         /// <returns>Task of ApiResponse (RecurrenceArray)</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<RecurrenceArray>> ListRecurrenceByCurrencyAsyncWithHttpInfo (string code, int? page = default(int?))
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<RecurrenceArray>> ListRecurrenceByCurrencyAsyncWithHttpInfo(string code, int? page = default(int?))
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -2704,13 +2702,13 @@ namespace FireflyIII.Api
             String[] _accepts = new String[] {
                 "application/json"
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
-            
+
             if (code != null)
                 localVarRequestOptions.PathParameters.Add("code", FireflyIII.Client.ClientUtils.ParameterToString(code)); // path parameter
             if (page != null)
@@ -2751,10 +2749,10 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination per 50. (optional)</param>
         /// <returns>RuleArray</returns>
-        public RuleArray ListRuleByCurrency (string code, int? page = default(int?))
+        public RuleArray ListRuleByCurrency(string code, int? page = default(int?))
         {
-             FireflyIII.Client.ApiResponse<RuleArray> localVarResponse = ListRuleByCurrencyWithHttpInfo(code, page);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<RuleArray> localVarResponse = ListRuleByCurrencyWithHttpInfo(code, page);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -2764,7 +2762,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination per 50. (optional)</param>
         /// <returns>ApiResponse of RuleArray</returns>
-        public FireflyIII.Client.ApiResponse< RuleArray > ListRuleByCurrencyWithHttpInfo (string code, int? page = default(int?))
+        public FireflyIII.Client.ApiResponse<RuleArray> ListRuleByCurrencyWithHttpInfo(string code, int? page = default(int?))
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -2807,7 +2805,7 @@ namespace FireflyIII.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get< RuleArray >("/api/v1/currencies/{code}/rules", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<RuleArray>("/api/v1/currencies/{code}/rules", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -2825,10 +2823,10 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination per 50. (optional)</param>
         /// <returns>Task of RuleArray</returns>
-        public async System.Threading.Tasks.Task<RuleArray> ListRuleByCurrencyAsync (string code, int? page = default(int?))
+        public async System.Threading.Tasks.Task<RuleArray> ListRuleByCurrencyAsync(string code, int? page = default(int?))
         {
-             FireflyIII.Client.ApiResponse<RuleArray> localVarResponse = await ListRuleByCurrencyAsyncWithHttpInfo(code, page);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<RuleArray> localVarResponse = await ListRuleByCurrencyAsyncWithHttpInfo(code, page);
+            return localVarResponse.Data;
 
         }
 
@@ -2839,7 +2837,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="page">Page number. The default pagination per 50. (optional)</param>
         /// <returns>Task of ApiResponse (RuleArray)</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<RuleArray>> ListRuleByCurrencyAsyncWithHttpInfo (string code, int? page = default(int?))
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<RuleArray>> ListRuleByCurrencyAsyncWithHttpInfo(string code, int? page = default(int?))
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -2855,13 +2853,13 @@ namespace FireflyIII.Api
             String[] _accepts = new String[] {
                 "application/json"
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
-            
+
             if (code != null)
                 localVarRequestOptions.PathParameters.Add("code", FireflyIII.Client.ClientUtils.ParameterToString(code)); // path parameter
             if (page != null)
@@ -2905,10 +2903,10 @@ namespace FireflyIII.Api
         /// <param name="endDate">A date formatted YYYY-MM-DD, to limit the list of transactions.  (optional)</param>
         /// <param name="type">Optional filter on the transaction type(s) returned (optional)</param>
         /// <returns>TransactionArray</returns>
-        public TransactionArray ListTransactionByCurrency (string code, int? page = default(int?), DateTime? startDate = default(DateTime?), DateTime? endDate = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
+        public TransactionArray ListTransactionByCurrency(string code, int? page = default(int?), DateTime? startDate = default(DateTime?), DateTime? endDate = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
         {
-             FireflyIII.Client.ApiResponse<TransactionArray> localVarResponse = ListTransactionByCurrencyWithHttpInfo(code, page, startDate, endDate, type);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<TransactionArray> localVarResponse = ListTransactionByCurrencyWithHttpInfo(code, page, startDate, endDate, type);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -2921,7 +2919,7 @@ namespace FireflyIII.Api
         /// <param name="endDate">A date formatted YYYY-MM-DD, to limit the list of transactions.  (optional)</param>
         /// <param name="type">Optional filter on the transaction type(s) returned (optional)</param>
         /// <returns>ApiResponse of TransactionArray</returns>
-        public FireflyIII.Client.ApiResponse< TransactionArray > ListTransactionByCurrencyWithHttpInfo (string code, int? page = default(int?), DateTime? startDate = default(DateTime?), DateTime? endDate = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
+        public FireflyIII.Client.ApiResponse<TransactionArray> ListTransactionByCurrencyWithHttpInfo(string code, int? page = default(int?), DateTime? startDate = default(DateTime?), DateTime? endDate = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -2975,7 +2973,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -2994,7 +2992,7 @@ namespace FireflyIII.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Get< TransactionArray >("/api/v1/currencies/{code}/transactions", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Get<TransactionArray>("/api/v1/currencies/{code}/transactions", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -3015,10 +3013,10 @@ namespace FireflyIII.Api
         /// <param name="endDate">A date formatted YYYY-MM-DD, to limit the list of transactions.  (optional)</param>
         /// <param name="type">Optional filter on the transaction type(s) returned (optional)</param>
         /// <returns>Task of TransactionArray</returns>
-        public async System.Threading.Tasks.Task<TransactionArray> ListTransactionByCurrencyAsync (string code, int? page = default(int?), DateTime? startDate = default(DateTime?), DateTime? endDate = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
+        public async System.Threading.Tasks.Task<TransactionArray> ListTransactionByCurrencyAsync(string code, int? page = default(int?), DateTime? startDate = default(DateTime?), DateTime? endDate = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
         {
-             FireflyIII.Client.ApiResponse<TransactionArray> localVarResponse = await ListTransactionByCurrencyAsyncWithHttpInfo(code, page, startDate, endDate, type);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<TransactionArray> localVarResponse = await ListTransactionByCurrencyAsyncWithHttpInfo(code, page, startDate, endDate, type);
+            return localVarResponse.Data;
 
         }
 
@@ -3032,7 +3030,7 @@ namespace FireflyIII.Api
         /// <param name="endDate">A date formatted YYYY-MM-DD, to limit the list of transactions.  (optional)</param>
         /// <param name="type">Optional filter on the transaction type(s) returned (optional)</param>
         /// <returns>Task of ApiResponse (TransactionArray)</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<TransactionArray>> ListTransactionByCurrencyAsyncWithHttpInfo (string code, int? page = default(int?), DateTime? startDate = default(DateTime?), DateTime? endDate = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<TransactionArray>> ListTransactionByCurrencyAsyncWithHttpInfo(string code, int? page = default(int?), DateTime? startDate = default(DateTime?), DateTime? endDate = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -3048,13 +3046,13 @@ namespace FireflyIII.Api
             String[] _accepts = new String[] {
                 "application/json"
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
-            
+
             if (code != null)
                 localVarRequestOptions.PathParameters.Add("code", FireflyIII.Client.ClientUtils.ParameterToString(code)); // path parameter
             if (page != null)
@@ -3087,7 +3085,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -3124,10 +3122,10 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="currency">JSON array or key&#x3D;value pairs with the necessary currency information. See the model for the exact specifications.</param>
         /// <returns>CurrencySingle</returns>
-        public CurrencySingle StoreCurrency (Currency currency)
+        public CurrencySingle StoreCurrency(Currency currency)
         {
-             FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = StoreCurrencyWithHttpInfo(currency);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = StoreCurrencyWithHttpInfo(currency);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -3136,7 +3134,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="currency">JSON array or key&#x3D;value pairs with the necessary currency information. See the model for the exact specifications.</param>
         /// <returns>ApiResponse of CurrencySingle</returns>
-        public FireflyIII.Client.ApiResponse< CurrencySingle > StoreCurrencyWithHttpInfo (Currency currency)
+        public FireflyIII.Client.ApiResponse<CurrencySingle> StoreCurrencyWithHttpInfo(Currency currency)
         {
             // verify the required parameter 'currency' is set
             if (currency == null)
@@ -3145,7 +3143,7 @@ namespace FireflyIII.Api
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
 
             String[] _contentTypes = new String[] {
-                "application/json", 
+                "application/json",
                 "application/x-www-form-urlencoded"
             };
 
@@ -3170,7 +3168,7 @@ namespace FireflyIII.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Post< CurrencySingle >("/api/v1/currencies", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Post<CurrencySingle>("/api/v1/currencies", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -3187,10 +3185,10 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="currency">JSON array or key&#x3D;value pairs with the necessary currency information. See the model for the exact specifications.</param>
         /// <returns>Task of CurrencySingle</returns>
-        public async System.Threading.Tasks.Task<CurrencySingle> StoreCurrencyAsync (Currency currency)
+        public async System.Threading.Tasks.Task<CurrencySingle> StoreCurrencyAsync(Currency currency)
         {
-             FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = await StoreCurrencyAsyncWithHttpInfo(currency);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = await StoreCurrencyAsyncWithHttpInfo(currency);
+            return localVarResponse.Data;
 
         }
 
@@ -3200,7 +3198,7 @@ namespace FireflyIII.Api
         /// <exception cref="FireflyIII.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="currency">JSON array or key&#x3D;value pairs with the necessary currency information. See the model for the exact specifications.</param>
         /// <returns>Task of ApiResponse (CurrencySingle)</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<CurrencySingle>> StoreCurrencyAsyncWithHttpInfo (Currency currency)
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<CurrencySingle>> StoreCurrencyAsyncWithHttpInfo(Currency currency)
         {
             // verify the required parameter 'currency' is set
             if (currency == null)
@@ -3210,7 +3208,7 @@ namespace FireflyIII.Api
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
 
             String[] _contentTypes = new String[] {
-                "application/json", 
+                "application/json",
                 "application/x-www-form-urlencoded"
             };
 
@@ -3218,13 +3216,13 @@ namespace FireflyIII.Api
             String[] _accepts = new String[] {
                 "application/json"
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
-            
+
             localVarRequestOptions.Data = currency;
 
             // authentication (firefly_iii_auth) required
@@ -3254,10 +3252,10 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="currency">JSON array with updated currency information. See the model for the exact specifications.</param>
         /// <returns>CurrencySingle</returns>
-        public CurrencySingle UpdateCurrency (string code, Currency currency)
+        public CurrencySingle UpdateCurrency(string code, Currency currency)
         {
-             FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = UpdateCurrencyWithHttpInfo(code, currency);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = UpdateCurrencyWithHttpInfo(code, currency);
+            return localVarResponse.Data;
         }
 
         /// <summary>
@@ -3267,7 +3265,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="currency">JSON array with updated currency information. See the model for the exact specifications.</param>
         /// <returns>ApiResponse of CurrencySingle</returns>
-        public FireflyIII.Client.ApiResponse< CurrencySingle > UpdateCurrencyWithHttpInfo (string code, Currency currency)
+        public FireflyIII.Client.ApiResponse<CurrencySingle> UpdateCurrencyWithHttpInfo(string code, Currency currency)
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -3280,7 +3278,7 @@ namespace FireflyIII.Api
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
 
             String[] _contentTypes = new String[] {
-                "application/json", 
+                "application/json",
                 "application/x-www-form-urlencoded"
             };
 
@@ -3307,7 +3305,7 @@ namespace FireflyIII.Api
             }
 
             // make the HTTP request
-            var localVarResponse = this.Client.Put< CurrencySingle >("/api/v1/currencies/{code}", localVarRequestOptions, this.Configuration);
+            var localVarResponse = this.Client.Put<CurrencySingle>("/api/v1/currencies/{code}", localVarRequestOptions, this.Configuration);
 
             if (this.ExceptionFactory != null)
             {
@@ -3325,10 +3323,10 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="currency">JSON array with updated currency information. See the model for the exact specifications.</param>
         /// <returns>Task of CurrencySingle</returns>
-        public async System.Threading.Tasks.Task<CurrencySingle> UpdateCurrencyAsync (string code, Currency currency)
+        public async System.Threading.Tasks.Task<CurrencySingle> UpdateCurrencyAsync(string code, Currency currency)
         {
-             FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = await UpdateCurrencyAsyncWithHttpInfo(code, currency);
-             return localVarResponse.Data;
+            FireflyIII.Client.ApiResponse<CurrencySingle> localVarResponse = await UpdateCurrencyAsyncWithHttpInfo(code, currency);
+            return localVarResponse.Data;
 
         }
 
@@ -3339,7 +3337,7 @@ namespace FireflyIII.Api
         /// <param name="code">The currency code.</param>
         /// <param name="currency">JSON array with updated currency information. See the model for the exact specifications.</param>
         /// <returns>Task of ApiResponse (CurrencySingle)</returns>
-        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<CurrencySingle>> UpdateCurrencyAsyncWithHttpInfo (string code, Currency currency)
+        public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<CurrencySingle>> UpdateCurrencyAsyncWithHttpInfo(string code, Currency currency)
         {
             // verify the required parameter 'code' is set
             if (code == null)
@@ -3353,7 +3351,7 @@ namespace FireflyIII.Api
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
 
             String[] _contentTypes = new String[] {
-                "application/json", 
+                "application/json",
                 "application/x-www-form-urlencoded"
             };
 
@@ -3361,13 +3359,13 @@ namespace FireflyIII.Api
             String[] _accepts = new String[] {
                 "application/json"
             };
-            
+
             foreach (var _contentType in _contentTypes)
                 localVarRequestOptions.HeaderParameters.Add("Content-Type", _contentType);
-            
+
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
-            
+
             if (code != null)
                 localVarRequestOptions.PathParameters.Add("code", FireflyIII.Client.ClientUtils.ParameterToString(code)); // path parameter
             localVarRequestOptions.Data = currency;

--- a/generated/src/FireflyIII/Api/ImportApi.cs
+++ b/generated/src/FireflyIII/Api/ImportApi.cs
@@ -640,7 +640,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -752,7 +752,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {

--- a/generated/src/FireflyIII/Api/LinksApi.cs
+++ b/generated/src/FireflyIII/Api/LinksApi.cs
@@ -662,7 +662,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse<Object> DeleteLinkTypeWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling LinksApi->DeleteLinkType");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -680,7 +680,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -723,7 +723,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<Object>> DeleteLinkTypeAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling LinksApi->DeleteLinkType");
 
 
@@ -742,7 +742,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -785,7 +785,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse<Object> DeleteTransactionLinkWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling LinksApi->DeleteTransactionLink");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -803,7 +803,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -846,7 +846,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<Object>> DeleteTransactionLinkAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling LinksApi->DeleteTransactionLink");
 
 
@@ -865,7 +865,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -909,7 +909,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< LinkTypeSingle > GetLinkTypeWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling LinksApi->GetLinkType");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -928,7 +928,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -972,7 +972,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<LinkTypeSingle>> GetLinkTypeAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling LinksApi->GetLinkType");
 
 
@@ -992,7 +992,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -1036,7 +1036,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< TransactionLinkSingle > GetTransactionLinkWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling LinksApi->GetTransactionLink");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -1055,7 +1055,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -1099,7 +1099,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<TransactionLinkSingle>> GetTransactionLinkAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling LinksApi->GetTransactionLink");
 
 
@@ -1119,7 +1119,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -1306,7 +1306,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< TransactionArray > ListTransactionByLinkTypeWithHttpInfo (int id, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling LinksApi->ListTransactionByLinkType");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -1325,7 +1325,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -1357,7 +1357,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -1417,7 +1417,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<TransactionArray>> ListTransactionByLinkTypeAsyncWithHttpInfo (int id, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling LinksApi->ListTransactionByLinkType");
 
 
@@ -1437,7 +1437,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -1469,7 +1469,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -1916,7 +1916,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< LinkTypeSingle > UpdateLinkTypeWithHttpInfo (int id, LinkType linkType)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling LinksApi->UpdateLinkType");
 
             // verify the required parameter 'linkType' is set
@@ -1941,7 +1941,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = linkType;
 
@@ -1988,7 +1988,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<LinkTypeSingle>> UpdateLinkTypeAsyncWithHttpInfo (int id, LinkType linkType)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling LinksApi->UpdateLinkType");
 
             // verify the required parameter 'linkType' is set
@@ -2014,7 +2014,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = linkType;
 
@@ -2061,7 +2061,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< TransactionLinkSingle > UpdateTransactionLinkWithHttpInfo (int id, TransactionLink transactionLink)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling LinksApi->UpdateTransactionLink");
 
             // verify the required parameter 'transactionLink' is set
@@ -2086,7 +2086,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = transactionLink;
 
@@ -2133,7 +2133,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<TransactionLinkSingle>> UpdateTransactionLinkAsyncWithHttpInfo (int id, TransactionLink transactionLink)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling LinksApi->UpdateTransactionLink");
 
             // verify the required parameter 'transactionLink' is set
@@ -2159,7 +2159,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = transactionLink;
 

--- a/generated/src/FireflyIII/Api/PiggyBanksApi.cs
+++ b/generated/src/FireflyIII/Api/PiggyBanksApi.cs
@@ -436,7 +436,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse<Object> DeletePiggyBankWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling PiggyBanksApi->DeletePiggyBank");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -454,7 +454,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -497,7 +497,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<Object>> DeletePiggyBankAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling PiggyBanksApi->DeletePiggyBank");
 
 
@@ -516,7 +516,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -560,7 +560,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< PiggyBankSingle > GetPiggyBankWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling PiggyBanksApi->GetPiggyBank");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -579,7 +579,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -623,7 +623,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<PiggyBankSingle>> GetPiggyBankAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling PiggyBanksApi->GetPiggyBank");
 
 
@@ -643,7 +643,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -689,7 +689,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< PiggyBankEventArray > ListEventByPiggyBankWithHttpInfo (int id, int? page = default(int?))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling PiggyBanksApi->ListEventByPiggyBank");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -708,7 +708,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -764,7 +764,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<PiggyBankEventArray>> ListEventByPiggyBankAsyncWithHttpInfo (int id, int? page = default(int?))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling PiggyBanksApi->ListEventByPiggyBank");
 
 
@@ -784,7 +784,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -1104,7 +1104,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< PiggyBankSingle > UpdatePiggyBankWithHttpInfo (int id, PiggyBank piggyBank)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling PiggyBanksApi->UpdatePiggyBank");
 
             // verify the required parameter 'piggyBank' is set
@@ -1129,7 +1129,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = piggyBank;
 
@@ -1176,7 +1176,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<PiggyBankSingle>> UpdatePiggyBankAsyncWithHttpInfo (int id, PiggyBank piggyBank)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling PiggyBanksApi->UpdatePiggyBank");
 
             // verify the required parameter 'piggyBank' is set
@@ -1202,7 +1202,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = piggyBank;
 

--- a/generated/src/FireflyIII/Api/RecurrencesApi.cs
+++ b/generated/src/FireflyIII/Api/RecurrencesApi.cs
@@ -486,7 +486,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse<Object> DeleteRecurrenceWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RecurrencesApi->DeleteRecurrence");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -504,7 +504,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -547,7 +547,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<Object>> DeleteRecurrenceAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RecurrencesApi->DeleteRecurrence");
 
 
@@ -566,7 +566,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -610,7 +610,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< RecurrenceSingle > GetRecurrenceWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RecurrencesApi->GetRecurrence");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -629,7 +629,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -673,7 +673,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<RecurrenceSingle>> GetRecurrenceAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RecurrencesApi->GetRecurrence");
 
 
@@ -693,7 +693,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -880,7 +880,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< TransactionArray > ListTransactionByRecurrenceWithHttpInfo (int id, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RecurrencesApi->ListTransactionByRecurrence");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -899,7 +899,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -931,7 +931,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -991,7 +991,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<TransactionArray>> ListTransactionByRecurrenceAsyncWithHttpInfo (int id, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), TransactionTypeFilter type = default(TransactionTypeFilter))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RecurrencesApi->ListTransactionByRecurrence");
 
 
@@ -1011,7 +1011,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -1043,7 +1043,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -1333,7 +1333,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< RecurrenceSingle > UpdateRecurrenceWithHttpInfo (int id, Recurrence recurrence)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RecurrencesApi->UpdateRecurrence");
 
             // verify the required parameter 'recurrence' is set
@@ -1358,7 +1358,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = recurrence;
 
@@ -1405,7 +1405,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<RecurrenceSingle>> UpdateRecurrenceAsyncWithHttpInfo (int id, Recurrence recurrence)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RecurrencesApi->UpdateRecurrence");
 
             // verify the required parameter 'recurrence' is set
@@ -1431,7 +1431,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = recurrence;
 

--- a/generated/src/FireflyIII/Api/RuleGroupsApi.cs
+++ b/generated/src/FireflyIII/Api/RuleGroupsApi.cs
@@ -556,7 +556,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse<Object> DeleteRuleGroupWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RuleGroupsApi->DeleteRuleGroup");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -574,7 +574,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -617,7 +617,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<Object>> DeleteRuleGroupAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RuleGroupsApi->DeleteRuleGroup");
 
 
@@ -636,7 +636,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -685,7 +685,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse<Object> FireRuleGroupWithHttpInfo (int id, DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), string accounts = default(string))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RuleGroupsApi->FireRuleGroup");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -703,7 +703,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (start != null)
             {
@@ -782,7 +782,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<Object>> FireRuleGroupAsyncWithHttpInfo (int id, DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), string accounts = default(string))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RuleGroupsApi->FireRuleGroup");
 
 
@@ -801,7 +801,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (start != null)
             {
@@ -875,7 +875,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< RuleGroupSingle > GetRuleGroupWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RuleGroupsApi->GetRuleGroup");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -894,7 +894,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -938,7 +938,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<RuleGroupSingle>> GetRuleGroupAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RuleGroupsApi->GetRuleGroup");
 
 
@@ -958,7 +958,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -1004,7 +1004,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< RuleArray > ListRuleByGroupWithHttpInfo (int id, int? page = default(int?))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RuleGroupsApi->ListRuleByGroup");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -1023,7 +1023,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -1079,7 +1079,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<RuleArray>> ListRuleByGroupAsyncWithHttpInfo (int id, int? page = default(int?))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RuleGroupsApi->ListRuleByGroup");
 
 
@@ -1099,7 +1099,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -1429,7 +1429,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< TransactionArray > TestRuleGroupWithHttpInfo (int id, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), int? searchLimit = default(int?), int? triggeredLimit = default(int?), string accounts = default(string))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RuleGroupsApi->TestRuleGroup");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -1448,7 +1448,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -1564,7 +1564,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<TransactionArray>> TestRuleGroupAsyncWithHttpInfo (int id, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), int? searchLimit = default(int?), int? triggeredLimit = default(int?), string accounts = default(string))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RuleGroupsApi->TestRuleGroup");
 
 
@@ -1584,7 +1584,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -1690,7 +1690,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< RuleGroupSingle > UpdateRuleGroupWithHttpInfo (int id, RuleGroup ruleGroup)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RuleGroupsApi->UpdateRuleGroup");
 
             // verify the required parameter 'ruleGroup' is set
@@ -1715,7 +1715,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = ruleGroup;
 
@@ -1762,7 +1762,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<RuleGroupSingle>> UpdateRuleGroupAsyncWithHttpInfo (int id, RuleGroup ruleGroup)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RuleGroupsApi->UpdateRuleGroup");
 
             // verify the required parameter 'ruleGroup' is set
@@ -1788,7 +1788,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = ruleGroup;
 

--- a/generated/src/FireflyIII/Api/RulesApi.cs
+++ b/generated/src/FireflyIII/Api/RulesApi.cs
@@ -510,7 +510,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse<Object> DeleteRuleWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RulesApi->DeleteRule");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -528,7 +528,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -571,7 +571,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<Object>> DeleteRuleAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RulesApi->DeleteRule");
 
 
@@ -590,7 +590,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -639,7 +639,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse<Object> FireRuleWithHttpInfo (int id, DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), string accounts = default(string))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RulesApi->FireRule");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -657,7 +657,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (start != null)
             {
@@ -736,7 +736,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<Object>> FireRuleAsyncWithHttpInfo (int id, DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), string accounts = default(string))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RulesApi->FireRule");
 
 
@@ -755,7 +755,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (start != null)
             {
@@ -829,7 +829,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< RuleSingle > GetRuleWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RulesApi->GetRule");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -848,7 +848,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -892,7 +892,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<RuleSingle>> GetRuleAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RulesApi->GetRule");
 
 
@@ -912,7 +912,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -1232,7 +1232,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< TransactionArray > TestRuleWithHttpInfo (int id, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), int? searchLimit = default(int?), int? triggeredLimit = default(int?), string accounts = default(string))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RulesApi->TestRule");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -1251,7 +1251,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -1367,7 +1367,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<TransactionArray>> TestRuleAsyncWithHttpInfo (int id, int? page = default(int?), DateTime? start = default(DateTime?), DateTime? end = default(DateTime?), int? searchLimit = default(int?), int? triggeredLimit = default(int?), string accounts = default(string))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RulesApi->TestRule");
 
 
@@ -1387,7 +1387,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -1493,7 +1493,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< RuleSingle > UpdateRuleWithHttpInfo (int id, Rule rule)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RulesApi->UpdateRule");
 
             // verify the required parameter 'rule' is set
@@ -1518,7 +1518,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = rule;
 
@@ -1565,7 +1565,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<RuleSingle>> UpdateRuleAsyncWithHttpInfo (int id, Rule rule)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling RulesApi->UpdateRule");
 
             // verify the required parameter 'rule' is set
@@ -1591,7 +1591,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = rule;
 

--- a/generated/src/FireflyIII/Api/TagsApi.cs
+++ b/generated/src/FireflyIII/Api/TagsApi.cs
@@ -1142,7 +1142,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -1254,7 +1254,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {

--- a/generated/src/FireflyIII/Api/TransactionsApi.cs
+++ b/generated/src/FireflyIII/Api/TransactionsApi.cs
@@ -536,8 +536,10 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse<Object> DeleteTransactionWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id <= 0)
+            {
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling TransactionsApi->DeleteTransaction");
+            }
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
 
@@ -554,7 +556,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -597,7 +599,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<Object>> DeleteTransactionAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling TransactionsApi->DeleteTransaction");
 
 
@@ -616,7 +618,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -660,7 +662,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< TransactionSingle > GetTransactionWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling TransactionsApi->GetTransaction");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -679,7 +681,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -723,7 +725,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<TransactionSingle>> GetTransactionAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling TransactionsApi->GetTransaction");
 
 
@@ -743,7 +745,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -787,7 +789,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< TransactionSingle > GetTransactionByJournalWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling TransactionsApi->GetTransactionByJournal");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -806,7 +808,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -850,7 +852,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<TransactionSingle>> GetTransactionByJournalAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling TransactionsApi->GetTransactionByJournal");
 
 
@@ -870,7 +872,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -916,7 +918,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< AttachmentArray > ListAttachmentByTransactionWithHttpInfo (int id, int? page = default(int?))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling TransactionsApi->ListAttachmentByTransaction");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -935,7 +937,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -991,7 +993,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<AttachmentArray>> ListAttachmentByTransactionAsyncWithHttpInfo (int id, int? page = default(int?))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling TransactionsApi->ListAttachmentByTransaction");
 
 
@@ -1011,7 +1013,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -1067,7 +1069,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< PiggyBankEventArray > ListEventByTransactionWithHttpInfo (int id, int? page = default(int?))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling TransactionsApi->ListEventByTransaction");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -1086,7 +1088,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -1142,7 +1144,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<PiggyBankEventArray>> ListEventByTransactionAsyncWithHttpInfo (int id, int? page = default(int?))
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling TransactionsApi->ListEventByTransaction");
 
 
@@ -1162,7 +1164,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             if (page != null)
             {
@@ -1267,7 +1269,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -1371,7 +1373,7 @@ namespace FireflyIII.Api
                     }
                 }
             }
-            if (type != null)
+            if (type != 0)
             {
                 foreach (var _kvp in FireflyIII.Client.ClientUtils.ParameterToMultiMap("", "type", type))
                 {
@@ -1554,7 +1556,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< TransactionSingle > UpdateTransactionWithHttpInfo (int id, Transaction transaction)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling TransactionsApi->UpdateTransaction");
 
             // verify the required parameter 'transaction' is set
@@ -1579,7 +1581,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = transaction;
 
@@ -1626,7 +1628,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<TransactionSingle>> UpdateTransactionAsyncWithHttpInfo (int id, Transaction transaction)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling TransactionsApi->UpdateTransaction");
 
             // verify the required parameter 'transaction' is set
@@ -1652,7 +1654,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = transaction;
 

--- a/generated/src/FireflyIII/Api/UsersApi.cs
+++ b/generated/src/FireflyIII/Api/UsersApi.cs
@@ -390,7 +390,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse<Object> DeleteUserWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling UsersApi->DeleteUser");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -408,7 +408,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -451,7 +451,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<Object>> DeleteUserAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling UsersApi->DeleteUser");
 
 
@@ -470,7 +470,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -514,7 +514,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< UserSingle > GetUserWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling UsersApi->GetUser");
 
             FireflyIII.Client.RequestOptions localVarRequestOptions = new FireflyIII.Client.RequestOptions();
@@ -533,7 +533,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -577,7 +577,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<UserSingle>> GetUserAsyncWithHttpInfo (int id)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling UsersApi->GetUser");
 
 
@@ -597,7 +597,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
 
             // authentication (firefly_iii_auth) required
@@ -907,7 +907,7 @@ namespace FireflyIII.Api
         public FireflyIII.Client.ApiResponse< UserSingle > UpdateUserWithHttpInfo (int id, User user)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling UsersApi->UpdateUser");
 
             // verify the required parameter 'user' is set
@@ -932,7 +932,7 @@ namespace FireflyIII.Api
             var localVarAccept = FireflyIII.Client.ClientUtils.SelectHeaderAccept(_accepts);
             if (localVarAccept != null) localVarRequestOptions.HeaderParameters.Add("Accept", localVarAccept);
 
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = user;
 
@@ -979,7 +979,7 @@ namespace FireflyIII.Api
         public async System.Threading.Tasks.Task<FireflyIII.Client.ApiResponse<UserSingle>> UpdateUserAsyncWithHttpInfo (int id, User user)
         {
             // verify the required parameter 'id' is set
-            if (id == null)
+            if (id == 0)
                 throw new FireflyIII.Client.ApiException(400, "Missing required parameter 'id' when calling UsersApi->UpdateUser");
 
             // verify the required parameter 'user' is set
@@ -1005,7 +1005,7 @@ namespace FireflyIII.Api
             foreach (var _accept in _accepts)
                 localVarRequestOptions.HeaderParameters.Add("Accept", _accept);
             
-            if (id != null)
+            
                 localVarRequestOptions.PathParameters.Add("id", FireflyIII.Client.ClientUtils.ParameterToString(id)); // path parameter
             localVarRequestOptions.Data = user;
 

--- a/generated/src/FireflyIII/Client/TolerantEnumConverter.cs
+++ b/generated/src/FireflyIII/Client/TolerantEnumConverter.cs
@@ -7,14 +7,30 @@ using System.Text;
 
 namespace FireflyIII.Client
 {
+    /// <summary>
+    /// Allows to convert to enum based on json, with some case tolerance because api might return all lower case.
+    /// </summary>
     public class TolerantEnumConverter : StringEnumConverter
     {
+        /// <summary>
+        /// Checks if it is possible to convert it might not be an enum type.
+        /// </summary>
+        /// <param name="objectType"></param>
+        /// <returns></returns>
         public override bool CanConvert(Type objectType)
         {
             Type type = IsNullableType(objectType) ? Nullable.GetUnderlyingType(objectType) : objectType;
             return type.IsEnum;
         }
 
+        /// <summary>
+        /// Extracts from json an enum or null if it fails.
+        /// </summary>
+        /// <param name="reader"></param>
+        /// <param name="objectType"></param>
+        /// <param name="existingValue"></param>
+        /// <param name="serializer"></param>
+        /// <returns></returns>
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {
             bool isNullable = IsNullableType(objectType);
@@ -65,6 +81,12 @@ namespace FireflyIII.Client
             return null;
         }
 
+        /// <summary>
+        /// Writes the value/enum into json.
+        /// </summary>
+        /// <param name="writer"></param>
+        /// <param name="value"></param>
+        /// <param name="serializer"></param>
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             writer.WriteValue(value.ToString());

--- a/generated/src/FireflyIII/Client/TolerantEnumConverter.cs
+++ b/generated/src/FireflyIII/Client/TolerantEnumConverter.cs
@@ -1,0 +1,78 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FireflyIII.Client
+{
+    public class TolerantEnumConverter : StringEnumConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            Type type = IsNullableType(objectType) ? Nullable.GetUnderlyingType(objectType) : objectType;
+            return type.IsEnum;
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            bool isNullable = IsNullableType(objectType);
+            Type enumType = isNullable ? Nullable.GetUnderlyingType(objectType) : objectType;
+
+            string[] names = Enum.GetNames(enumType);
+
+            if (reader.TokenType == JsonToken.String)
+            {
+                string enumText = reader.Value.ToString();
+
+                if (!string.IsNullOrEmpty(enumText))
+                {
+                    string match = names
+                        .Where(n => string.Equals(n, enumText, StringComparison.OrdinalIgnoreCase))
+                        .FirstOrDefault();
+
+                    if (match != null)
+                    {
+                        return Enum.Parse(enumType, match);
+                    }
+                }
+            }
+            else if (reader.TokenType == JsonToken.Integer)
+            {
+                int enumVal = Convert.ToInt32(reader.Value);
+                int[] values = (int[])Enum.GetValues(enumType);
+                if (values.Contains(enumVal))
+                {
+                    return Enum.Parse(enumType, enumVal.ToString());
+                }
+            }
+
+            if (!isNullable)
+            {
+                string defaultName = names
+                    .Where(n => string.Equals(n, "Unknown", StringComparison.OrdinalIgnoreCase))
+                    .FirstOrDefault();
+
+                if (defaultName == null)
+                {
+                    defaultName = names.First();
+                }
+
+                return Enum.Parse(enumType, defaultName);
+            }
+
+            return null;
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.ToString());
+        }
+
+        private bool IsNullableType(Type t)
+        {
+            return (t.IsGenericType && t.GetGenericTypeDefinition() == typeof(Nullable<>));
+        }
+    }
+}

--- a/generated/src/FireflyIII/Model/Account.cs
+++ b/generated/src/FireflyIII/Model/Account.cs
@@ -22,6 +22,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System.ComponentModel.DataAnnotations;
 using OpenAPIDateConverter = FireflyIII.Client.OpenAPIDateConverter;
+using TolerantEnumConverter = FireflyIII.Client.TolerantEnumConverter;
 
 namespace FireflyIII.Model
 {
@@ -104,7 +105,7 @@ namespace FireflyIII.Model
         /// Is only mandatory when the type is asset.
         /// </summary>
         /// <value>Is only mandatory when the type is asset.</value>
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonConverter(typeof(TolerantEnumConverter))]
         public enum AccountRoleEnum
         {
             /// <summary>
@@ -337,14 +338,14 @@ namespace FireflyIII.Model
         /// Gets or Sets OpeningBalance
         /// </summary>
         [DataMember(Name="opening_balance", EmitDefaultValue=false)]
-        public double OpeningBalance { get; set; }
+        public double? OpeningBalance { get; set; }
 
         /// <summary>
         /// Gets or Sets OpeningBalanceDate
         /// </summary>
         [DataMember(Name="opening_balance_date", EmitDefaultValue=false)]
         [JsonConverter(typeof(OpenAPIDateConverter))]
-        public DateTime OpeningBalanceDate { get; set; }
+        public DateTime? OpeningBalanceDate { get; set; }
 
         /// <summary>
         /// Gets or Sets VirtualBalance
@@ -418,7 +419,7 @@ namespace FireflyIII.Model
         /// </summary>
         /// <value>Mandatory when type is liability. Amount of money in the liability. Must be positive.</value>
         [DataMember(Name="liability_amount", EmitDefaultValue=false)]
-        public double LiabilityAmount { get; set; }
+        public double? LiabilityAmount { get; set; }
 
         /// <summary>
         /// Mandatory when type is liability. Start date for the liability.
@@ -426,14 +427,14 @@ namespace FireflyIII.Model
         /// <value>Mandatory when type is liability. Start date for the liability.</value>
         [DataMember(Name="liability_start_date", EmitDefaultValue=false)]
         [JsonConverter(typeof(OpenAPIDateConverter))]
-        public DateTime LiabilityStartDate { get; set; }
+        public DateTime? LiabilityStartDate { get; set; }
 
         /// <summary>
         /// Mandatory when type is liability. Interest percentage.
         /// </summary>
         /// <value>Mandatory when type is liability. Interest percentage.</value>
         [DataMember(Name="interest", EmitDefaultValue=false)]
-        public float Interest { get; set; }
+        public float? Interest { get; set; }
 
         /// <summary>
         /// Gets or Sets Notes

--- a/generated/src/FireflyIII/Model/Attachment.cs
+++ b/generated/src/FireflyIII/Model/Attachment.cs
@@ -127,7 +127,7 @@ namespace FireflyIII.Model
 
             this.Model = model;
             // to ensure "modelId" is required (not null)
-            if (modelId == null)
+            if (modelId == 0)
             {
                 throw new InvalidDataException("modelId is a required property for Attachment and cannot be null");
             }

--- a/generated/src/FireflyIII/Model/AvailableBudget.cs
+++ b/generated/src/FireflyIII/Model/AvailableBudget.cs
@@ -47,7 +47,7 @@ namespace FireflyIII.Model
         public AvailableBudget(int currencyId = default(int), string currencyCode = default(string), double amount = default(double), DateTime start = default(DateTime), DateTime end = default(DateTime))
         {
             // to ensure "amount" is required (not null)
-            if (amount == null)
+            if (amount == 0)
             {
                 throw new InvalidDataException("amount is a required property for AvailableBudget and cannot be null");
             }

--- a/generated/src/FireflyIII/Model/Bill.cs
+++ b/generated/src/FireflyIII/Model/Bill.cs
@@ -107,7 +107,7 @@ namespace FireflyIII.Model
             }
 
             // to ensure "amountMin" is required (not null)
-            if (amountMin == null)
+            if (amountMin == 0)
             {
                 throw new InvalidDataException("amountMin is a required property for Bill and cannot be null");
             }
@@ -117,7 +117,7 @@ namespace FireflyIII.Model
             }
 
             // to ensure "amountMax" is required (not null)
-            if (amountMax == null)
+            if (amountMax == 0)
             {
                 throw new InvalidDataException("amountMax is a required property for Bill and cannot be null");
             }

--- a/generated/src/FireflyIII/Model/BudgetLimit.cs
+++ b/generated/src/FireflyIII/Model/BudgetLimit.cs
@@ -48,7 +48,7 @@ namespace FireflyIII.Model
         public BudgetLimit(int currencyId = default(int), string currencyCode = default(string), int budgetId = default(int), DateTime start = default(DateTime), DateTime end = default(DateTime), double amount = default(double))
         {
             // to ensure "budgetId" is required (not null)
-            if (budgetId == null)
+            if (budgetId == 0)
             {
                 throw new InvalidDataException("budgetId is a required property for BudgetLimit and cannot be null");
             }
@@ -78,7 +78,7 @@ namespace FireflyIII.Model
             }
 
             // to ensure "amount" is required (not null)
-            if (amount == null)
+            if (amount == 0)
             {
                 throw new InvalidDataException("amount is a required property for BudgetLimit and cannot be null");
             }

--- a/generated/src/FireflyIII/Model/PiggyBank.cs
+++ b/generated/src/FireflyIII/Model/PiggyBank.cs
@@ -59,7 +59,7 @@ namespace FireflyIII.Model
             }
 
             // to ensure "accountId" is required (not null)
-            if (accountId == null)
+            if (accountId == 0)
             {
                 throw new InvalidDataException("accountId is a required property for PiggyBank and cannot be null");
             }
@@ -69,7 +69,7 @@ namespace FireflyIII.Model
             }
 
             // to ensure "targetAmount" is required (not null)
-            if (targetAmount == null)
+            if (targetAmount == 0)
             {
                 throw new InvalidDataException("targetAmount is a required property for PiggyBank and cannot be null");
             }

--- a/generated/src/FireflyIII/Model/RecurrenceTransaction.cs
+++ b/generated/src/FireflyIII/Model/RecurrenceTransaction.cs
@@ -81,7 +81,7 @@ namespace FireflyIII.Model
             }
 
             // to ensure "amount" is required (not null)
-            if (amount == null)
+            if (amount == 0)
             {
                 throw new InvalidDataException("amount is a required property for RecurrenceTransaction and cannot be null");
             }

--- a/generated/src/FireflyIII/Model/Rule.cs
+++ b/generated/src/FireflyIII/Model/Rule.cs
@@ -89,7 +89,7 @@ namespace FireflyIII.Model
             }
 
             // to ensure "ruleGroupId" is required (not null)
-            if (ruleGroupId == null)
+            if (ruleGroupId == 0)
             {
                 throw new InvalidDataException("ruleGroupId is a required property for Rule and cannot be null");
             }

--- a/generated/src/FireflyIII/Model/TransactionLink.cs
+++ b/generated/src/FireflyIII/Model/TransactionLink.cs
@@ -47,7 +47,7 @@ namespace FireflyIII.Model
         public TransactionLink(int linkTypeId = default(int), string linkTypeName = default(string), int inwardId = default(int), int outwardId = default(int), string notes = default(string))
         {
             // to ensure "linkTypeId" is required (not null)
-            if (linkTypeId == null)
+            if (linkTypeId == 0)
             {
                 throw new InvalidDataException("linkTypeId is a required property for TransactionLink and cannot be null");
             }
@@ -57,7 +57,7 @@ namespace FireflyIII.Model
             }
 
             // to ensure "inwardId" is required (not null)
-            if (inwardId == null)
+            if (inwardId == 0)
             {
                 throw new InvalidDataException("inwardId is a required property for TransactionLink and cannot be null");
             }
@@ -67,7 +67,7 @@ namespace FireflyIII.Model
             }
 
             // to ensure "outwardId" is required (not null)
-            if (outwardId == null)
+            if (outwardId == 0)
             {
                 throw new InvalidDataException("outwardId is a required property for TransactionLink and cannot be null");
             }

--- a/generated/src/FireflyIII/Model/TransactionSplit.cs
+++ b/generated/src/FireflyIII/Model/TransactionSplit.cs
@@ -156,7 +156,7 @@ namespace FireflyIII.Model
             }
 
             // to ensure "amount" is required (not null)
-            if (amount == null)
+            if (amount == 0)
             {
                 throw new InvalidDataException("amount is a required property for TransactionSplit and cannot be null");
             }


### PR DESCRIPTION
Hi, so between the database and the enums there were case differences that caused a compare to fail.
Since it uses set values from db, we fixed it by making an ignore case compare.

Also while I was at it, removed all warnings, where most were just an if(int != null) it would never be null. Changed it all to if(int != 0).
